### PR TITLE
ManageIQPerformance::Reporting::RequestfileBuilder is not loaded

### DIFF
--- a/lib/manageiq_performance/tasks/benchmark.rake
+++ b/lib/manageiq_performance/tasks/benchmark.rake
@@ -17,6 +17,7 @@ namespace :manageiq_performance do
 
   desc "Build a RequestFile for benchmarking"
   task :build_request_file => :environment do
+    require "manageiq_performance/reporting/requestfile_builder"
     ManageIQPerformance::Reporting::RequestfileBuilder.new
   end
 end


### PR DESCRIPTION
`rake manageiq_performance:build_request_file`

produces this
```
NameError: uninitialized constant ManageIQPerformance::Reporting
/usr/local/opt/rbenv/versions/2.2.6/bin/bundle:23:in `load'
/usr/local/opt/rbenv/versions/2.2.6/bin/bundle:23:in `<main>'
Tasks: TOP => manageiq_performance:build_request_file
(See full trace by running task with --trace)
```

So I think we need to require it in rake task.

@NickLaMuro 

