### PR TITLE
Ignore other controllers without models

### DIFF
--- a/lib/manageiq_performance/reporting/param_builder/id.rb
+++ b/lib/manageiq_performance/reporting/param_builder/id.rb
@@ -7,9 +7,12 @@ module ManageIQPerformance
           consumption
           configuration
           container_topology
+          ems_infra_dashboard
           middleware_topology
           network_topology
           subnet_topology
+          cloud_topology
+          infra_topology
           container_dashboard
           dashboard
         ]


### PR DESCRIPTION
`
rake manageiq_performance:build_request_file
`

generates this error

```
Generating Requestfile........................................................................................................................................................................................................................................rake aborted!
NameError: uninitialized constant EmsInfraDashboard
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller.rb:83:in `model'
/usr/local/opt/rbenv/versions/2.2.6/bin/bundle:23:in `load'
/usr/local/opt/rbenv/versions/2.2.6/bin/bundle:23:in `<main>'
Tasks: TOP => manageiq_performance:build_request_file
(See full trace by running task with --trace)
```

@NickLaMuro 
