### PR TITLE
Allow travis to run the test suite properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+- '2.3.1'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |t, task_args|
+  t.rspec_opts = "--format documentation"
+end
+
+task :default => :spec

--- a/manageiq-performance.gemspec
+++ b/manageiq-performance.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = Dir["bin/*"].map { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", ">= 1.3.0", "< 2.0"
   spec.add_development_dependency "rake",    "~> 10.0"
   spec.add_development_dependency "rspec",   "~> 3.5.0"
 


### PR DESCRIPTION
This is done by:

* Matching the bundler version requirement used by Rails, which is also in range of the version that is currently on Travis by default (1.7.6).
* Adding a `.travis.yml` file that determines the version of ruby to use (one that works with `rack` and used by `manageiq`)
* Adds a Rakefile that, by default, runs the test suite.

Fixes #7