### PR TITLE
Prevent duplicate ActiveRecordQueries::Logger instances

### DIFF
--- a/lib/manageiq_performance/middlewares/active_record_queries.rb
+++ b/lib/manageiq_performance/middlewares/active_record_queries.rb
@@ -7,7 +7,13 @@ module ManageIQPerformance
       def active_record_queries_initialize
         logger = ::ManageIQPerformance::Middlewares::ActiveRecordQueries::Logger.new
         %w(sql.active_record instantiation.active_record).each do |event|
-          ActiveSupport::Notifications.subscribe(event, logger)
+          existing_notifiers = ActiveSupport::Notifications.notifier.listeners_for('sql.active_record').map do |s|
+            s.instance_variable_get(:@delegate).class
+          end
+
+          unless existing_notifiers.include? logger.class
+            ActiveSupport::Notifications.subscribe(event, logger)
+          end
         end
       end
 

--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -2,16 +2,6 @@ require "active_support"
 require "active_record"
 require "manageiq_performance/middleware"
 
-# Stub rails
-module Rails
-  Application = Struct.new :config
-  Config      = Struct.new :filter_parameters
-
-  def self.application
-    Application.new Config.new([:password, :verify, :data])
-  end
-end
-
 middleware_defaults = ManageIQPerformance::Configuration::DEFAULTS["middleware"]
 
 shared_examples "middleware functionality for" do |middleware_order|

--- a/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
+++ b/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
@@ -1,0 +1,28 @@
+require "active_record"
+require "manageiq_performance/middleware"
+require "manageiq_performance/middlewares/active_record_queries"
+
+class FakeMiddleware
+  include ManageIQPerformance::Middlewares::ActiveRecordQueries
+
+  def initialize
+    active_record_queries_initialize
+  end
+end
+
+describe ManageIQPerformance::Middlewares::ActiveRecordQueries do
+  context "with more than one instance of the middleware" do
+    before(:each) do
+      2.times { FakeMiddleware.new }
+    end
+
+    it "does not add duplicate ActiveSupport::Notification subscribers" do
+      existing_notifiers = ActiveSupport::Notifications.notifier.listeners_for('sql.active_record').map do |s|
+        s.instance_variable_get(:@delegate).class
+      end
+
+      logger_class = ::ManageIQPerformance::Middlewares::ActiveRecordQueries::Logger
+      expect( existing_notifiers.select {|n| n == logger_class }.count ).to eq(1)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,9 +40,16 @@ RSpec.configure do |config|
   end
 end
 
-# Stub Rails root
+# Stub Rails
 module Rails
+  Application = Struct.new :config
+  Config      = Struct.new :filter_parameters
+
   def self.root
     File.expand_path File.join(".."), File.dirname(__FILE__)
+  end
+
+  def self.application
+    Application.new Config.new([:password, :verify, :data])
   end
 end


### PR DESCRIPTION
In the future, we might be instantiating more than one instance of the middleware to use it for something like a:

```ruby
ManageIQPerformance.profile {  do_stuff!  }
```

But because of how `ActiveRecordQueries` queries sets up a `ActiveSupport::Notifications.subscribe`, duplicate subscription handlers will write to the Thread variable for each handler that has been initialized.

To prevent this, the private API of the `ActiveSupport::Notifications.notifier` (`ActiveSupport::Notifications::Fanout`) is queried against to find the `listeners_for` the specific even that we are about to add a notifier for.  If it our logger class isn't present, the extra will be added, otherwise it will assume one is initialized already.