### PR TITLE
Adds ManageIQPeformance::profile

### DIFF
--- a/lib/manageiq_performance/middleware.rb
+++ b/lib/manageiq_performance/middleware.rb
@@ -76,6 +76,7 @@ module ManageIQPerformance
     end
 
     def performance_middleware_finish env
+      env["MIQ_PERFORMANCE_END_TIME"] = (Time.now.to_f * 1000000).to_i
       performance_middleware.reverse.each do |middleware|
         send "#{middleware}_finish", env
       end
@@ -93,7 +94,8 @@ module ManageIQPerformance
     name ||= caller.first.match(/`(|.*\s)([a-z_\(\)]+)>?'$/)[2].gsub(/[^a-z_]/,'')
     env  = {
       Middleware::PERFORMANCE_HEADER => true,
-      "REQUEST_PATH"                 => name
+      "REQUEST_PATH"                 => name,
+      "HTTP_MIQ_PERF_TIMESTAMP"      => (Time.now.to_f * 1000000).to_i
     }
 
     ManageIQPerformance::Middleware.new(code).call(env)

--- a/lib/manageiq_performance/middleware.rb
+++ b/lib/manageiq_performance/middleware.rb
@@ -88,4 +88,15 @@ module ManageIQPerformance
       end
     end
   end
+
+  def self.profile name = nil, &code
+    name ||= caller.first.match(/`(|.*\s)([a-z_\(\)]+)>?'$/)[2].gsub(/[^a-z_]/,'')
+    env  = {
+      Middleware::PERFORMANCE_HEADER => true,
+      "REQUEST_PATH"                 => name
+    }
+
+    ManageIQPerformance::Middleware.new(code).call(env)
+  end
+
 end

--- a/lib/manageiq_performance/middleware_storage/file.rb
+++ b/lib/manageiq_performance/middleware_storage/file.rb
@@ -46,7 +46,7 @@ module ManageIQPerformance
       end
 
       def format_path_for_filename path
-        request_path = path.to_s.gsub("/", "%")[1..-1]
+        request_path = path.to_s.gsub("/", "%").sub(/^%/, '')
         request_path = "root" if request_path == ""
         request_path
       end

--- a/lib/manageiq_performance/middleware_storage/file.rb
+++ b/lib/manageiq_performance/middleware_storage/file.rb
@@ -52,7 +52,7 @@ module ManageIQPerformance
       end
 
       def request_timestamp env
-        env['HTTP_MIQ_PERF_TIMESTAMP'] || Time.now.to_i
+        env['HTTP_MIQ_PERF_TIMESTAMP'] || (Time.now.to_f * 1000000).to_i
       end
     end
   end

--- a/lib/manageiq_performance/middlewares/active_support_timers.rb
+++ b/lib/manageiq_performance/middlewares/active_support_timers.rb
@@ -20,7 +20,7 @@ module ManageIQPerformance
 
       def active_support_timers_finish(env)
         if Thread.current[:miq_perf_request_timer_data].nil? and env["HTTP_MIQ_PERF_TIMESTAMP"]
-          time = (env["MIQ_PERFORMANCE_END_TIME"] - env["HTTP_MIQ_PERF_TIMESTAMP"]) / 1000
+          time = (env["MIQ_PERFORMANCE_END_TIME"].to_i - env["HTTP_MIQ_PERF_TIMESTAMP"].to_i) / 1000
           Thread.current[:miq_perf_request_timer_data] = {
             "path" => env["REQUEST_PATH"],
             "time" => { "total" => time }

--- a/lib/manageiq_performance/middlewares/active_support_timers.rb
+++ b/lib/manageiq_performance/middlewares/active_support_timers.rb
@@ -19,6 +19,14 @@ module ManageIQPerformance
       def active_support_timers_start(env); end
 
       def active_support_timers_finish(env)
+        if Thread.current[:miq_perf_request_timer_data].nil? and env["HTTP_MIQ_PERF_TIMESTAMP"]
+          time = (env["MIQ_PERFORMANCE_END_TIME"] - env["HTTP_MIQ_PERF_TIMESTAMP"]) / 1000
+          Thread.current[:miq_perf_request_timer_data] = {
+            "path" => env["REQUEST_PATH"],
+            "time" => { "total" => time }
+          }
+        end
+
         if Thread.current[:miq_perf_request_timer_data]
           save_report env, :info,
                       active_support_timers_short_form_data,

--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -26,9 +26,14 @@ class ProfilingTestClass
 end
 
 shared_examples "middleware functionality for" do |middleware_order|
+  before do
+    allow(Time).to receive(:now).and_return("1234567")
+  end
+
   let(:basic_env) {
     {
-      ManageIQPerformance::Middleware::PERFORMANCE_HEADER => true
+      ManageIQPerformance::Middleware::PERFORMANCE_HEADER => true,
+      "HTTP_MIQ_PERF_TIMESTAMP"                           => 1234567000000
     }
   }
 

--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -4,7 +4,34 @@ require "manageiq_performance/middleware"
 
 middleware_defaults = ManageIQPerformance::Configuration::DEFAULTS["middleware"]
 
+class ProfilingTestClass
+  def self.test_profiling
+    ManageIQPerformance.profile { 1 + 1 }
+  end
+
+  def self.test_profiling_in_block
+    1.times do
+      ManageIQPerformance.profile { 1 + 1 }
+    end
+  end
+
+  def self.test_profile_eval_script
+    <<-EOF.gsub(/^\s*/, '')
+      begin
+      ManageIQPerformance.profile { 1 + 1 }
+      rescue
+      end
+    EOF
+  end
+end
+
 shared_examples "middleware functionality for" do |middleware_order|
+  let(:basic_env) {
+    {
+      ManageIQPerformance::Middleware::PERFORMANCE_HEADER => true
+    }
+  }
+
   middleware_order.each do |name|
     it "loads #{name} middleware" do
       expect(subject.private_methods.include? "#{name}_start".to_sym).to  be true
@@ -34,7 +61,7 @@ shared_examples "middleware functionality for" do |middleware_order|
       expect(subject).to receive(:performance_middleware_start).once
       expect(subject).to receive(:performance_middleware_finish).once
 
-      subject.call({ ManageIQPerformance::Middleware::PERFORMANCE_HEADER => true})
+      subject.call(basic_env)
     end
 
     it "runs the middleware in order" do
@@ -44,7 +71,7 @@ shared_examples "middleware functionality for" do |middleware_order|
         expect(subject).to receive("#{name}_start").ordered
       end
 
-      subject.call({ ManageIQPerformance::Middleware::PERFORMANCE_HEADER => true})
+      subject.call(basic_env)
     end
 
     it "finishes the middleware in reverse order" do
@@ -54,7 +81,107 @@ shared_examples "middleware functionality for" do |middleware_order|
         expect(subject).to receive("#{name}_finish").ordered
       end
 
-      subject.call({ ManageIQPerformance::Middleware::PERFORMANCE_HEADER => true})
+      subject.call(basic_env)
+    end
+  end
+
+  describe "ManageIQPerformance::profile" do
+    let(:work) { Proc.new { Thread.current[:result] = (1..10).to_a.inject(0, :+) } }
+    let(:middleware_instance) { ManageIQPerformance::Middleware.new work }
+    let(:run_profile) do
+      Proc.new do
+        ManageIQPerformance.profile { work }
+      end
+    end
+
+    it "runs the code in the block" do
+      ManageIQPerformance.profile { Thread.current[:result] = 42 }
+
+      expect(Thread.current[:result]).to eq(42)
+    end
+
+    it "runs the middleware in order" do
+      allow(ManageIQPerformance::Middleware).to receive(:new).and_return(middleware_instance)
+      middleware_order.each do |name|
+        expect(middleware_instance).to receive("#{name}_start").ordered
+      end
+
+      run_profile.call
+    end
+
+    it "finishes the middleware in reverse order" do
+      allow(ManageIQPerformance::Middleware).to receive(:new).and_return(middleware_instance)
+      middleware_order.reverse.each do |name|
+        expect(middleware_instance).to receive("#{name}_finish").ordered
+      end
+
+      run_profile.call
+    end
+
+    context "with a name given" do
+      it "sets the REQUEST_PATH to the name in the env" do
+        allow(ManageIQPerformance::Middleware).to receive(:new).and_return(middleware_instance)
+        expected_env = basic_env.merge("REQUEST_PATH" => "my_name")
+        expect(middleware_instance).to receive(:call).with(expected_env)
+
+        ManageIQPerformance.profile("my_name") { work }
+      end
+    end
+
+    # Testing that when a name is given, we are creating a name based on the
+    # call stack something that only has letters and underscores for the
+    # generated filename.  Don't really want to create another method for this,
+    # but this is some dense regexp code that is being done to generate this
+    # name.
+    context "without a name given" do
+      # Example callstack line:
+      #
+      #   /spec/manageiq_performance/middleware_spec.rb:94:in `block (3 levels) in <top (required)>'
+      #
+      it "generates a name for REQUEST_PATH from the caller" do
+        allow(ManageIQPerformance::Middleware).to receive(:new).and_return(middleware_instance)
+        expected_env = basic_env.merge("REQUEST_PATH" => "required")
+        expect(middleware_instance).to receive(:call).with(expected_env)
+
+        ManageIQPerformance.profile { work }
+      end
+
+      # Example callstack line:
+      #
+      #   /spec/manageiq_performance/middleware_spec.rb:14:in `test_profiling'
+      #
+      it "name generator handles method names in call stack" do
+        allow(ManageIQPerformance::Middleware).to receive(:new).and_return(middleware_instance)
+        expected_env = basic_env.merge("REQUEST_PATH" => "test_profiling")
+        expect(middleware_instance).to receive(:call).with(expected_env)
+
+        ProfilingTestClass.test_profiling
+      end
+
+      # Example callstack line:
+      #
+      #   /spec/manageiq_performance/middleware_spec.rb:19:in `block in test_profiling_in_block'
+      #
+      it "name generator handles block references in call stack" do
+        allow(ManageIQPerformance::Middleware).to receive(:new).and_return(middleware_instance)
+        expected_env = basic_env.merge("REQUEST_PATH" => "test_profiling_in_block")
+        expect(middleware_instance).to receive(:call).with(expected_env)
+
+        ProfilingTestClass.test_profiling_in_block
+      end
+
+      # Example callstack line:
+      #
+      #   (eval):64:in `<top (required)>'
+      #
+      it "name generator handles block references in call stack" do
+        puts "THIS ONE"
+        allow(ManageIQPerformance::Middleware).to receive(:new).and_return(middleware_instance)
+        expected_env = basic_env.merge("REQUEST_PATH" => "required")
+        expect(middleware_instance).to receive(:call).with(expected_env)
+
+        eval ProfilingTestClass.test_profile_eval_script
+      end
     end
   end
 

--- a/spec/manageiq_performance/middleware_storage/file_spec.rb
+++ b/spec/manageiq_performance/middleware_storage/file_spec.rb
@@ -88,6 +88,12 @@ describe ManageIQPerformance::MiddlewareStorage::File do
       expect(result).to eq "index"
     end
 
+    it "maintains string if there is no leading '/'" do
+      request_path = "index"
+      result = subject.send(:format_path_for_filename, request_path)
+      expect(result).to eq "index"
+    end
+
     it "updates the request_path to use '%' instead of '/'" do
       request_path = "/foo/bar/baz"
       result = subject.send(:format_path_for_filename, request_path)

--- a/spec/manageiq_performance/middleware_storage/file_spec.rb
+++ b/spec/manageiq_performance/middleware_storage/file_spec.rb
@@ -38,7 +38,7 @@ describe ManageIQPerformance::MiddlewareStorage::File do
       data = "my middleware dataz"
       data_writer = Proc.new { data }
       suite_dir = "#{proj_dir}/tmp/manageiq_performance/run_1234567"
-      expected_filename = "foo%bar/request_1234567.info"
+      expected_filename = "foo%bar/request_1234567000000.info"
 
       filestore.record env, :info, nil, data_writer
       expect(File.read "#{suite_dir}/#{expected_filename}").to eq data
@@ -48,7 +48,7 @@ describe ManageIQPerformance::MiddlewareStorage::File do
       data = {"foo" => "my middleware dataz"}
       data_writer = Proc.new { data }
       suite_dir = "#{proj_dir}/tmp/manageiq_performance/run_1234567"
-      expected_filename = "foo%bar/request_1234567.info"
+      expected_filename = "foo%bar/request_1234567000000.info"
 
       filestore.record env, :info, nil, data_writer
       expect(File.read "#{suite_dir}/#{expected_filename}").to eq data.to_yaml
@@ -59,19 +59,19 @@ describe ManageIQPerformance::MiddlewareStorage::File do
     it "builds a filename from the env['REQUEST_PATH'] variable" do
       env = {"REQUEST_PATH" => "/foo/bar/baz"}
       result = subject.send(:filename, env)
-      expect(result).to eq "foo%bar%baz/request_1234567.data"
+      expect(result).to eq "foo%bar%baz/request_1234567000000.data"
     end
 
     it "prefixes the route with 'root' if the REQUEST_PATH is '/'" do
       env = {"REQUEST_PATH" => "/"}
       result = subject.send(:filename, env)
-      expect(result).to eq "root/request_1234567.data"
+      expect(result).to eq "root/request_1234567000000.data"
     end
 
     it "updates the ext if one is passed in" do
       env = {"REQUEST_PATH" => "/"}
       result = subject.send(:filename, env, :info)
-      expect(result).to eq "root/request_1234567.info"
+      expect(result).to eq "root/request_1234567000000.info"
     end
   end
 
@@ -97,7 +97,7 @@ describe ManageIQPerformance::MiddlewareStorage::File do
 
   describe "request_timestamp" do
     it "returns `Time.now` by default" do
-      expect(subject.send :request_timestamp, {}).to eq 1234567
+      expect(subject.send :request_timestamp, {}).to eq 1234567000000
     end
 
     it "returns the value of env['HTTP_MIQ_PERF_TIMESTAMP'] if set" do

--- a/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
+++ b/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
@@ -2,7 +2,7 @@ require "active_record"
 require "manageiq_performance/middleware"
 require "manageiq_performance/middlewares/active_record_queries"
 
-class FakeMiddleware
+class FakeQueriesMiddleware
   include ManageIQPerformance::Middlewares::ActiveRecordQueries
 
   def initialize
@@ -13,7 +13,7 @@ end
 describe ManageIQPerformance::Middlewares::ActiveRecordQueries do
   context "with more than one instance of the middleware" do
     before(:each) do
-      2.times { FakeMiddleware.new }
+      2.times { FakeQueriesMiddleware.new }
     end
 
     it "does not add duplicate 'sql.active_record' subscribers" do

--- a/spec/manageiq_performance/middlewares/active_support_timers_spec.rb
+++ b/spec/manageiq_performance/middlewares/active_support_timers_spec.rb
@@ -61,6 +61,13 @@ describe ManageIQPerformance::Middlewares::ActiveSupportTimers do
 
         subject.send :active_support_timers_finish, env
       end
+
+      it "does not blow up in HTTP_MIQ_PERF_TIMESTAMP is sent as a string" do
+        env = {"HTTP_MIQ_PERF_TIMESTAMP" => "1000000", "MIQ_PERFORMANCE_END_TIME" => 1026000}
+        expect(subject).to receive(:save_report).with(env, :info, short_data, long_data)
+
+        subject.send :active_support_timers_finish, env
+      end
     end
 
     after { Thread.current[:miq_perf_request_timer_data] = nil }

--- a/spec/manageiq_performance/middlewares/active_support_timers_spec.rb
+++ b/spec/manageiq_performance/middlewares/active_support_timers_spec.rb
@@ -1,0 +1,68 @@
+require "active_support/notifications"
+require "manageiq_performance/middleware"
+require "manageiq_performance/middlewares/active_support_timers"
+
+class FakeTimersMiddleware
+  include ManageIQPerformance::Middlewares::ActiveSupportTimers
+
+  def initialize
+    active_support_timers_initialize
+  end
+
+  private
+
+  def save_report env, info, short, long
+  end
+end
+
+describe ManageIQPerformance::Middlewares::ActiveSupportTimers do
+  let(:sample_timer_data) {
+    {
+      "controller" => "FooController",
+      "action"     => "index",
+      "path"       => "/foos",
+      "format"     => "html",
+      "status"     => 200,
+      "time"       => {
+        "views"         => 5,
+        "activerecord"  => 20,
+        "total"         => 26
+      }
+    }
+  }
+  let(:short_data) { subject.send :active_support_timers_short_form_data }
+  let(:long_data)  { subject.send :active_support_timers_long_form_data  }
+
+  describe "#active_support_timers_finish" do
+    subject { FakeTimersMiddleware.new }
+
+    context "with timer data set in the Thread variable" do
+      before { Thread.current[:miq_perf_request_timer_data] = sample_timer_data }
+
+      it "saves the data" do
+        env = {"MIQ_PERFORMANCE_END_TIME" => 1026000}
+        expect(subject).to receive(:save_report).with(env, :info, short_data, long_data)
+
+        subject.send :active_support_timers_finish, env
+      end
+    end
+
+    context "with timer data not set in the Thread variable" do
+      it "does not save the data if MIQ_PERF_TIMESTAMP is not set in the env" do
+        env = {"MIQ_PERFORMANCE_END_TIME" => 1026000}
+        expect(subject).to receive(:save_report).never
+
+        subject.send :active_support_timers_finish, env
+      end
+
+      it "saves the the data with a timestamp generated from MIQ_PERF_TIMESTAMP and MIQ_PERFORMANCE_END_TIME" do
+        env = {"HTTP_MIQ_PERF_TIMESTAMP" => 1000000, "MIQ_PERFORMANCE_END_TIME" => 1026000}
+        expect(subject).to receive(:save_report).with(env, :info, short_data, long_data)
+
+        subject.send :active_support_timers_finish, env
+      end
+    end
+
+    after { Thread.current[:miq_perf_request_timer_data] = nil }
+  end
+end


### PR DESCRIPTION
This is to be used for profiling something in line in irb, a script, or a something like a Rails runner.  Something like this:

```ruby
irb> ManageIQPerformance.profile { Rbac.search Vm, ... }
```

Uses the passed in block as the `app` for the middleware, and sets up a dummy `env` that will make sure the middleware is triggered, and there is a "name" for any file that is generated (if the file storage backend is being used).  A name can also be passed in if the user wishes to name the "request" for the run.

```ruby
irb> ManageIQPerformance.profile("test_rbac_before_fix") { Rbac.search Vm, ... }
```

Also, in addition to naming it in the same way it would be as if it was a web-request being profiled, it also allows for the `ActiveSupportTimers` to report the time taken, even though a `ActiveSupport::Notification` isn't fired (because no request was done).  This is done through a simple timer included in the base middleware, and used as a fallback in the `ActiveSupportTimers` middleware plugin.

Links
-----
* https://www.pivotaltracker.com/story/show/137479755