### PR TITLE
Fix missing instantiation.active_record subscriptions

### DIFF
--- a/lib/manageiq_performance/middlewares/active_record_queries.rb
+++ b/lib/manageiq_performance/middlewares/active_record_queries.rb
@@ -7,7 +7,7 @@ module ManageIQPerformance
       def active_record_queries_initialize
         logger = ::ManageIQPerformance::Middlewares::ActiveRecordQueries::Logger.new
         %w(sql.active_record instantiation.active_record).each do |event|
-          existing_notifiers = ActiveSupport::Notifications.notifier.listeners_for('sql.active_record').map do |s|
+          existing_notifiers = ActiveSupport::Notifications.notifier.listeners_for(event).map do |s|
             s.instance_variable_get(:@delegate).class
           end
 

--- a/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
+++ b/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
@@ -16,8 +16,17 @@ describe ManageIQPerformance::Middlewares::ActiveRecordQueries do
       2.times { FakeMiddleware.new }
     end
 
-    it "does not add duplicate ActiveSupport::Notification subscribers" do
-      existing_notifiers = ActiveSupport::Notifications.notifier.listeners_for('sql.active_record').map do |s|
+    it "does not add duplicate 'sql.active_record' subscribers" do
+      existing_notifiers  = ActiveSupport::Notifications.notifier.listeners_for("sql.active_record").map do |s|
+        s.instance_variable_get(:@delegate).class
+      end
+
+      logger_class = ::ManageIQPerformance::Middlewares::ActiveRecordQueries::Logger
+      expect( existing_notifiers.select {|n| n == logger_class }.count ).to eq(1)
+    end
+
+    it "does not add duplicate 'instantiation.active_record' subscribers" do
+      existing_notifiers = ActiveSupport::Notifications.notifier.listeners_for("instantiation.active_record").map do |s|
         s.instance_variable_get(:@delegate).class
       end
 


### PR DESCRIPTION
When fixing duplicate ActiveSupport::Notifications subscriptions in commit 623b2ab :

[https://github.com/ManageIQ/manageiq-performance/commit/623b2ab](https://github.com/ManageIQ/manageiq-performance/commit/623b2ab)

The `instantiation.active_record` subscription was removed entirely by mistake because the check on existing subscriptions was checking against the specific subscription, 'sql.active_record', instead of for the event which was currently being set.

This resulted in the `rows` not being tallied when profiling code.


Links
-----
* https://github.com/ManageIQ/manageiq-performance/pull/10