### PR TITLE
Don't use developer's .miq_performance

### DIFF
--- a/spec/manageiq_performance/configuration_spec.rb
+++ b/spec/manageiq_performance/configuration_spec.rb
@@ -10,6 +10,7 @@ describe ManageIQPerformance::Configuration do
 
   before(:each) do
     allow(Dir).to receive(:home).and_return(home_dir)
+    described_class.instance_variable_set :@config_file_location, nil
   end
 
   around(:example) do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 $LOAD_PATH.unshift File.expand_path "../..", __FILE__
 
+require 'tempfile'
+
+CONFIG_FILE_NAME = Tempfile.new('config').tap { |x| x.close } # sorry, not unlinking
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -37,7 +40,7 @@ RSpec.configure do |config|
     ManageIQPerformance.instance_variable_set :@config, nil
 
     if defined? ManageIQPerformance::Configuration
-      ManageIQPerformance::Configuration.instance_variable_set :@config_file_location, nil
+      ManageIQPerformance::Configuration.instance_variable_set :@config_file_location, CONFIG_FILE_NAME
     end
   end
 end


### PR DESCRIPTION
If a developer has an `.miq_performance` rc configuration file, it will read that file and tests run wonky.

This PR disables the auto detection and auto load for the rc file.

fixes #8 