### PR TITLE
Less memory for logging

### DIFF
--- a/lib/manageiq_performance/configuration.rb
+++ b/lib/manageiq_performance/configuration.rb
@@ -17,6 +17,7 @@ module ManageIQPerformance
       "log_dir"              => "log",
       "skip_schema_queries"  => true,
       "include_stack_traces" => false,
+      "include_sql_queries"  => true,
       "stacktrace_cleaner"   => "simple",
       "requestor"            => {
         "username"     => "admin",
@@ -76,6 +77,10 @@ module ManageIQPerformance
 
     def skip_schema_queries?
       self["skip_schema_queries"]
+    end
+
+    def include_sql_queries?
+      self["include_sql_queries"]
     end
 
     def include_stack_traces?

--- a/lib/manageiq_performance/middlewares/active_record_queries.rb
+++ b/lib/manageiq_performance/middlewares/active_record_queries.rb
@@ -131,11 +131,13 @@ module ManageIQPerformance
         end
 
         def include_trace?
-          @include_trace ||= ManageIQPerformance.config.include_stack_traces?
+          return @include_trace if defined?(@include_trace)
+          @include_trace = ManageIQPerformance.config.include_stack_traces?
         end
 
         def skip_schema_queries?
-          @skip_schema_queries ||= ManageIQPerformance.config.skip_schema_queries?
+          return @skip_schema_queries if defined?(@skip_schema_queries)
+          @skip_schema_queries = ManageIQPerformance.config.skip_schema_queries?
         end
 
         # ORACLE and PG query types

--- a/spec/manageiq_performance/configuration_spec.rb
+++ b/spec/manageiq_performance/configuration_spec.rb
@@ -103,6 +103,11 @@ describe ManageIQPerformance::Configuration do
       expect(ManageIQPerformance.config["include_stack_traces"]).to eq(false)
     end
 
+    it "defines ManageIQPerformance.config.include_sql_queries?" do
+      expect(ManageIQPerformance.config.include_sql_queries?).to eq(true)
+      expect(ManageIQPerformance.config["include_sql_queries"]).to eq(true)
+    end
+
     it "defines ManageIQPerformance.config.stacktrace_cleaner" do
       expect(ManageIQPerformance.config.stacktrace_cleaner).to eq(ManageIQPerformance::StacktraceCleaners::Simple)
       expect(ManageIQPerformance.config["stacktrace_cleaner"]).to eq("simple")
@@ -169,6 +174,7 @@ describe ManageIQPerformance::Configuration do
         log_dir: tmp/my_log_dir
         skip_schema_queries: false
         include_stack_traces: true
+        include_sql_queries: false
         stacktrace_cleaner: rails
         requestor:
           username: foobar
@@ -211,6 +217,11 @@ describe ManageIQPerformance::Configuration do
     it "defines ManageIQPerformance.config.include_stack_traces?" do
       expect(ManageIQPerformance.config.include_stack_traces?).to eq(true)
       expect(ManageIQPerformance.config["include_stack_traces"]).to eq(true)
+    end
+
+    it "defines ManageIQPerformance.config.include_sql_queries?" do
+      expect(ManageIQPerformance.config.include_sql_queries?).to eq(false)
+      expect(ManageIQPerformance.config["include_sql_queries"]).to eq(false)
     end
 
     it "defines ManageIQPerformance.config.stacktrace_cleaner" do


### PR DESCRIPTION
When we are in log only mode, give option to not record queries.
This will cut down on memory use for queries

https://www.pivotaltracker.com/story/show/140076603

viewing [[diff with whitespace off]](https://github.com/ManageIQ/manageiq-performance/pull/15/files?w=1) may be easier to review