### PR TITLE
disable stackprof by default

### DIFF
--- a/lib/manageiq_performance/configuration.rb
+++ b/lib/manageiq_performance/configuration.rb
@@ -25,8 +25,8 @@ module ManageIQPerformance
         "read_timeout" => 300,
         "ignore_ssl"   => false
       },
+      # also have middleware: stackprof
       "middleware"           => %w[
-        stackprof
         active_support_timers
         active_record_queries
       ],

--- a/spec/manageiq_performance/configuration_spec.rb
+++ b/spec/manageiq_performance/configuration_spec.rb
@@ -139,7 +139,7 @@ describe ManageIQPerformance::Configuration do
     end
 
     it "defines ManageIQPerformance.config.middleware" do
-      middleware = %w[stackprof active_support_timers active_record_queries]
+      middleware = %w[active_support_timers active_record_queries]
       expect(ManageIQPerformance.config.middleware).to match_array(middleware)
       expect(ManageIQPerformance.config["middleware"]).to match_array(middleware)
     end

--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -199,7 +199,7 @@ describe ManageIQPerformance::Middleware do
   context "with no configuration set (default)" do
     subject { described_class.new(Proc.new {}) }
     include_examples "middleware functionality for",
-                     [:stackprof, :active_support_timers, :active_record_queries]
+                     [:active_support_timers, :active_record_queries]
   end
 
   context "with only stackprof and active_record_queries middlewares" do


### PR DESCRIPTION
stackprof is great, but it is quite heavy handed.

Disable it by default, but users can enable when needed...