### PR TITLE
Fix multiple issues with reporter.rb

### DIFF
--- a/lib/manageiq_performance/reporter.rb
+++ b/lib/manageiq_performance/reporter.rb
@@ -119,7 +119,7 @@ module ManageIQPerformance
         @report_data[request_id][hdr] and hdr
       end
 
-      @report_data[request_id][count_header].count.times do |i|
+      (@report_data[request_id][count_header] || []).count.times do |i|
         print_row do |hdr|
           value = HEADERS[hdr].map { |header_column|
             @report_data[request_id].fetch(header_column, [])[i] || 0

--- a/lib/manageiq_performance/reporter.rb
+++ b/lib/manageiq_performance/reporter.rb
@@ -38,7 +38,7 @@ module ManageIQPerformance
 
     def gather_request_times request_dir, request_id
       Dir["#{request_dir}/*.info"].inject(@report_data[request_id]) do |data, info_file|
-        info = YAML.load_file(info_file)
+        info = YAML.load_file(info_file) || {}
 
         data["ms"]           ||= []
         data["activerecord"] ||= []

--- a/lib/manageiq_performance/reporter.rb
+++ b/lib/manageiq_performance/reporter.rb
@@ -58,8 +58,8 @@ module ManageIQPerformance
         data["queries"]      ||= []
         data["rows"]         ||= []
         data["elapsed_time"] ||= []
-        data["queries"]      << queries[:total_queries]
-        data["rows"]         << queries[:total_rows]
+        data["queries"]      << queries[:total_queries].to_i
+        data["rows"]         << queries[:total_rows].to_i
         data["elapsed_time"] << queries.fetch(:queries, []).map {|q| q[:elapsed_time] }.inject(0.0, :+)
         data
       end


### PR DESCRIPTION
Small fixes that catch some corner cases in the `reporter.rb`.

This is going to need to have some tests wrapped around it, and refactored heavily if we are going to want to continue having new middlewares like #20 being added (which was the original plan).  As briefly discussed in the last commit message, the headers that would be described in the table should be uniquely grabbed based on the data available, and not a hardcoded constant like is currently shown here.  Beyond the scope of this PR though.