### PR TITLE
Fix stackprof not being stopped in tests

### DIFF
--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -110,12 +110,14 @@ shared_examples "middleware functionality for" do |middleware_order|
       middleware_order.each do |name|
         expect(middleware_instance).to receive("#{name}_start").ordered
       end
+      allow(subject).to receive(:performance_middleware_finish)
 
       run_profile.call
     end
 
     it "finishes the middleware in reverse order" do
       allow(ManageIQPerformance::Middleware).to receive(:new).and_return(middleware_instance)
+      allow(subject).to receive(:performance_middleware_start)
       middleware_order.reverse.each do |name|
         expect(middleware_instance).to receive("#{name}_finish").ordered
       end


### PR DESCRIPTION
When the `ManageIQPerformance::profile` method was added, some tests confirming the middleware methods were executed in the correct order were copied from the original code testing the middleware `call` functionality that tested the same thing.

Unfortunately, the stubs were inplace to watch either the `start` or `stop` methods that were being tested, but not the opposite ones that weren't being tested.  This means that if stackprof was one of the enabled middleware in the tests, and the program ended in a way that the start was left un-stopped (I am assuming), then stackprof could "barf" at the end of the test run, and cause an non-zero exit status do to a segfault.

This unfortunately was a non-deterministic test failure, and even running the same seed wouldn't necessarily reproduce the issue.  That said, when running the test suite before this fix, you could run in to the segfault within 25 runs of the suite.  Now, it doesn't seem to happen after hundreds.


QA Steps
--------

1. Checkout these changes by either:
   - applying the changes:
     
     ```console
     git apply <(curl -L https://github.com/ManageIQ/manageiq-performance/pull/23)`
     ```
     
   - checking out the branch:
     
     ```
     $ git remote add ManageIQ https://github.com/ManageIQ/manageiq-performance.git
     $ git checkout ManageIQ/fix_non_deterministic_stackprof_test_failure`
     ```
     
2. Run the test suite:  `$ rake`
  
3. Repeat multiple times until you are confident that this fix is not malarkey. :smile: