### PR TITLE
Fixes CSRF token issues with benchmark cli

### DIFF
--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -81,7 +81,6 @@ module ManageIQPerformance
     def full_request_headers
       timestamp = (Time.now.to_f * 1000000).to_i.to_s
       @headers.merge({
-        'X-CSRF-Token'       => csrf_token, # first so session is set correctly
         'Cookie'             => @session,
         'MIQ_PERF_TIMESTAMP' => timestamp
       })

--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -68,12 +68,12 @@ module ManageIQPerformance
       log "--> getting csrf_token..." unless @csrf_token
       @csrf_token ||= nethttp_request(:get, '/', :headers => BASE_HEADERS)
                         .body.scan(CSRF_TAG_REGEX).first.to_s
-                        .match(CSRF_TOKEN_REGEX)[1]
+                        .match(CSRF_TOKEN_REGEX) {|match| match[1] }
     end
 
     def login_headers
       BASE_HEADERS.merge({
-        'X-CSRF-Token' => csrf_token, # first so session is set correctly
+        'X-CSRF-Token' => csrf_token.to_s, # first so session is set correctly
         'Cookie'       => @session,
       })
     end


### PR DESCRIPTION
In https://github.com/ManageIQ/manageiq-ui-classic/issues/451 we removed the CSRF token in our login page, which breaks the requestor code when trying to log in and the csrf token is no where to be found.

By using the block form, we can return the proper match in the CSRF token regexp if it exists, but still return `nil` if it does not, which will be fine it the header is blank (which is why a `.to_s` was added to the caller).

Instead of removing the csrf token lookup on login, we are keeping this in place to allow this to be used on older versions of the MIQ application, otherwise we would need conditional logic for different versions of the application.

Also, removes the csrf token lookup in the `full_request_headers` since it never made sense to be there in the first place, and was just now requiring an extra lookup to the manageiq UI worker since the token was now set to `nil` on login.


Links
-----
* https://github.com/ManageIQ/manageiq-ui-classic/issues/451