### PR TITLE
Add interfaces for changing the global config

### DIFF
--- a/lib/manageiq_performance/configuration.rb
+++ b/lib/manageiq_performance/configuration.rb
@@ -143,4 +143,8 @@ module ManageIQPerformance
   def self.config
     @config ||= Configuration.load_config
   end
+
+  def self.config= config
+    @config = Configuration.new config
+  end
 end

--- a/lib/manageiq_performance/configuration.rb
+++ b/lib/manageiq_performance/configuration.rb
@@ -64,7 +64,7 @@ module ManageIQPerformance
     end
 
     def initialize(config={})
-      @config             = config
+      @config_hash        = config
       @default_dir        = self["default_dir"]
       @log_dir            = self["log_dir"]
       @requestor          = requestor_config config.fetch("requestor", {})
@@ -74,7 +74,7 @@ module ManageIQPerformance
     end
 
     def [](key)
-      @config.fetch key, DEFAULTS[key]
+      @config_hash.fetch key, DEFAULTS[key]
     end
 
     def skip_schema_queries?

--- a/lib/manageiq_performance/configuration.rb
+++ b/lib/manageiq_performance/configuration.rb
@@ -40,9 +40,8 @@ module ManageIQPerformance
       }
     }.freeze
 
-    attr_reader :default_dir, :log_dir, :requestor,
-                :middleware, :middleware_storage,
-                :browser_mode
+    attr_reader :config_hash, :default_dir, :log_dir, :requestor,
+                :middleware, :middleware_storage, :browser_mode
 
     def self.load_config
       new load_config_file
@@ -146,5 +145,13 @@ module ManageIQPerformance
 
   def self.config= config
     @config = Configuration.new config
+  end
+
+  def self.with_config temporary_config
+    old_config = @config
+    @config = Configuration.new config.config_hash.merge(temporary_config)
+    yield
+  ensure
+    @config = old_config
   end
 end

--- a/spec/manageiq_performance/configuration_spec.rb
+++ b/spec/manageiq_performance/configuration_spec.rb
@@ -311,4 +311,47 @@ describe ManageIQPerformance::Configuration do
       expect(ManageIQPerformance.config["default_dir"]).to eq "foo/bar/baz"
     end
   end
+
+  describe "with a temporary set of config changes" do
+    let(:config_changes) { { "default_dir" => "foo/bar/baz" } }
+
+    it "only makes the changes to default_dir during the duration of the block" do
+      expect(ManageIQPerformance.config.default_dir).to eq "tmp/manageiq_performance"
+      expect(ManageIQPerformance.config["default_dir"]).to eq "tmp/manageiq_performance"
+
+      ManageIQPerformance.with_config(config_changes) do
+        expect(ManageIQPerformance.config.default_dir).to eq "foo/bar/baz"
+        expect(ManageIQPerformance.config["default_dir"]).to eq "foo/bar/baz"
+      end
+
+      expect(ManageIQPerformance.config.default_dir).to eq "tmp/manageiq_performance"
+      expect(ManageIQPerformance.config["default_dir"]).to eq "tmp/manageiq_performance"
+    end
+
+    it "inherits values set in the previous config" do
+      ManageIQPerformance.config = { "include_sql_queries" => false }
+
+      expect(ManageIQPerformance.config.include_sql_queries?).to eq false
+      expect(ManageIQPerformance.config["include_sql_queries"]).to eq false
+      expect(ManageIQPerformance.config.default_dir).to eq "tmp/manageiq_performance"
+      expect(ManageIQPerformance.config["default_dir"]).to eq "tmp/manageiq_performance"
+
+      ManageIQPerformance.with_config(config_changes) do
+        expect(ManageIQPerformance.config.include_sql_queries?).to eq false
+        expect(ManageIQPerformance.config["include_sql_queries"]).to eq false
+        expect(ManageIQPerformance.config.default_dir).to eq "foo/bar/baz"
+        expect(ManageIQPerformance.config["default_dir"]).to eq "foo/bar/baz"
+      end
+
+      expect(ManageIQPerformance.config.default_dir).to eq "tmp/manageiq_performance"
+      expect(ManageIQPerformance.config["default_dir"]).to eq "tmp/manageiq_performance"
+    end
+
+    it "returns the result of the block" do
+      result = ManageIQPerformance.with_config(config_changes) do
+        ManageIQPerformance.config.default_dir
+      end
+      expect(result).to eq config_changes["default_dir"]
+    end
+  end
 end

--- a/spec/manageiq_performance/configuration_spec.rb
+++ b/spec/manageiq_performance/configuration_spec.rb
@@ -2,6 +2,12 @@ require "manageiq_performance/configuration"
 require "manageiq_performance/stacktrace_cleaners/simple"
 require "fileutils"
 
+# Few things to know about this spec file:
+#
+#   * The spec helper has a callback in it to clear out the global "config"
+#   after each test (needed in other places)
+#   * We use a fake home dir and project dir to avoid loading a user's actual
+#   config when running tests on a developer's machine
 describe ManageIQPerformance::Configuration do
   let(:spec_dir) { File.expand_path "..", File.dirname(__FILE__) }
   let(:spec_tmp) { "#{spec_dir}/tmp" }

--- a/spec/manageiq_performance/configuration_spec.rb
+++ b/spec/manageiq_performance/configuration_spec.rb
@@ -195,90 +195,90 @@ describe ManageIQPerformance::Configuration do
     end
 
     it "defines ManageIQPerformance.config.default_dir" do
-      expect(ManageIQPerformance.config.default_dir).to eq("/tmp/miq_perf")
-      expect(ManageIQPerformance.config["default_dir"]).to eq("/tmp/miq_perf")
+      expect(ManageIQPerformance.config.default_dir).to eq "/tmp/miq_perf"
+      expect(ManageIQPerformance.config["default_dir"]).to eq "/tmp/miq_perf"
     end
 
     it "defines ManageIQPerformance.config.log_dir" do
-      expect(ManageIQPerformance.config.log_dir).to eq("tmp/my_log_dir")
-      expect(ManageIQPerformance.config["log_dir"]).to eq("tmp/my_log_dir")
+      expect(ManageIQPerformance.config.log_dir).to eq "tmp/my_log_dir"
+      expect(ManageIQPerformance.config["log_dir"]).to eq "tmp/my_log_dir"
     end
 
     it "defines ManageIQPerformance.config.skip_schema_queries?" do
-      expect(ManageIQPerformance.config.skip_schema_queries?).to eq(false)
-      expect(ManageIQPerformance.config["skip_schema_queries"]).to eq(false)
+      expect(ManageIQPerformance.config.skip_schema_queries?).to eq false
+      expect(ManageIQPerformance.config["skip_schema_queries"]).to eq false
     end
 
     it "defines ManageIQPerformance.config.include_stack_traces?" do
-      expect(ManageIQPerformance.config.include_stack_traces?).to eq(true)
-      expect(ManageIQPerformance.config["include_stack_traces"]).to eq(true)
+      expect(ManageIQPerformance.config.include_stack_traces?).to eq true
+      expect(ManageIQPerformance.config["include_stack_traces"]).to eq true
     end
 
     it "defines ManageIQPerformance.config.include_sql_queries?" do
-      expect(ManageIQPerformance.config.include_sql_queries?).to eq(false)
-      expect(ManageIQPerformance.config["include_sql_queries"]).to eq(false)
+      expect(ManageIQPerformance.config.include_sql_queries?).to eq false
+      expect(ManageIQPerformance.config["include_sql_queries"]).to eq false
     end
 
     it "defines ManageIQPerformance.config.include_memsize?" do
-      expect(ManageIQPerformance.config.include_memsize?).to eq(true)
-      expect(ManageIQPerformance.config["include_memsize"]).to eq(true)
+      expect(ManageIQPerformance.config.include_memsize?).to eq true
+      expect(ManageIQPerformance.config["include_memsize"]).to eq true
     end
 
     it "defines ManageIQPerformance.config.stacktrace_cleaner" do
-      expect(ManageIQPerformance.config.stacktrace_cleaner).to eq(ManageIQPerformance::StacktraceCleaners::Rails)
-      expect(ManageIQPerformance.config["stacktrace_cleaner"]).to eq("rails")
+      expect(ManageIQPerformance.config.stacktrace_cleaner).to eq ManageIQPerformance::StacktraceCleaners::Rails
+      expect(ManageIQPerformance.config["stacktrace_cleaner"]).to eq "rails"
     end
 
     it "defines ManageIQPerformance.config.requestor.username" do
-      expect(ManageIQPerformance.config.requestor.username).to eq("foobar")
-      expect(ManageIQPerformance.config["requestor"]["username"]).to eq("foobar")
+      expect(ManageIQPerformance.config.requestor.username).to eq "foobar"
+      expect(ManageIQPerformance.config["requestor"]["username"]).to eq "foobar"
     end
 
     it "defines ManageIQPerformance.config.requestor.password" do
-      expect(ManageIQPerformance.config.requestor.password).to eq("p@ssw0rd")
-      expect(ManageIQPerformance.config["requestor"]["password"]).to eq("p@ssw0rd")
+      expect(ManageIQPerformance.config.requestor.password).to eq "p@ssw0rd"
+      expect(ManageIQPerformance.config["requestor"]["password"]).to eq "p@ssw0rd"
     end
 
     it "defines ManageIQPerformance.config.requestor.host" do
-      expect(ManageIQPerformance.config.requestor.host).to eq("http://123.45.67.89")
-      expect(ManageIQPerformance.config["requestor"]["host"]).to eq("http://123.45.67.89")
+      expect(ManageIQPerformance.config.requestor.host).to eq "http://123.45.67.89"
+      expect(ManageIQPerformance.config["requestor"]["host"]).to eq "http://123.45.67.89"
     end
 
     it "defines ManageIQPerformance.config.requestor.read_timeout" do
-      expect(ManageIQPerformance.config.requestor.read_timeout).to eq(400)
-      expect(ManageIQPerformance.config["requestor"]["read_timeout"]).to eq(400)
+      expect(ManageIQPerformance.config.requestor.read_timeout).to eq 400
+      expect(ManageIQPerformance.config["requestor"]["read_timeout"]).to eq 400
     end
 
     it "defines ManageIQPerformance.config.requestor.ignore_ssl" do
-      expect(ManageIQPerformance.config.requestor.ignore_ssl).to eq(true)
-      expect(ManageIQPerformance.config["requestor"]["ignore_ssl"]).to eq(true)
+      expect(ManageIQPerformance.config.requestor.ignore_ssl).to eq true
+      expect(ManageIQPerformance.config["requestor"]["ignore_ssl"]).to eq true
     end
 
     it "defines ManageIQPerformance.config.requestor.requestfile_dir" do
-      expect(ManageIQPerformance.config.requestor.requestfile_dir).to eq("config")
-      expect(ManageIQPerformance.config["requestor"]["requestfile_dir"]).to eq("config")
+      expect(ManageIQPerformance.config.requestor.requestfile_dir).to eq "config"
+      expect(ManageIQPerformance.config["requestor"]["requestfile_dir"]).to eq "config"
     end
 
     it "defines ManageIQPerformance.config.middleware" do
       middleware = %w[active_support_timers stackprof active_record_queries]
-      expect(ManageIQPerformance.config.middleware).to match_array(middleware)
-      expect(ManageIQPerformance.config["middleware"]).to match_array(middleware)
+      expect(ManageIQPerformance.config.middleware).to match_array middleware
+      expect(ManageIQPerformance.config["middleware"]).to match_array middleware
     end
 
     it "defines ManageIQPerformance.config.middleware" do
       middleware_storage = %w[file log]
-      expect(ManageIQPerformance.config.middleware_storage).to match_array(middleware_storage)
-      expect(ManageIQPerformance.config["middleware_storage"]).to match_array(middleware_storage)
+      expect(ManageIQPerformance.config.middleware_storage).to eq middleware_storage
+      expect(ManageIQPerformance.config["middleware_storage"]).to eq middleware_storage
     end
 
     it "defines ManageIQPerformance.config.browser_mode.enabled?" do
-      expect(ManageIQPerformance.config.browser_mode.enabled?).to eq(true)
-      expect(ManageIQPerformance.config["browser_mode"]["enabled"]).to eq(true)
+      expect(ManageIQPerformance.config.browser_mode.enabled?).to eq true
+      expect(ManageIQPerformance.config["browser_mode"]["enabled"]).to eq true
     end
 
     it "defines ManageIQPerformance.config.browser_mode.always_on?" do
-      expect(ManageIQPerformance.config.browser_mode.always_on?).to eq(true)
-      expect(ManageIQPerformance.config["browser_mode"]["always_on"]).to eq(true)
+      expect(ManageIQPerformance.config.browser_mode.always_on?).to eq true
+      expect(ManageIQPerformance.config["browser_mode"]["always_on"]).to eq true
     end
   end
 
@@ -294,8 +294,8 @@ describe ManageIQPerformance::Configuration do
     end
 
     it "uses the simple StacktraceCleaner by default" do
-      expect(ManageIQPerformance.config.stacktrace_cleaner).to eq(ManageIQPerformance::StacktraceCleaners::Simple)
-      expect(ManageIQPerformance.config["stacktrace_cleaner"]).to eq("foobar")
+      expect(ManageIQPerformance.config.stacktrace_cleaner).to eq ManageIQPerformance::StacktraceCleaners::Simple
+      expect(ManageIQPerformance.config["stacktrace_cleaner"]).to eq "foobar"
     end
   end
 


### PR DESCRIPTION
In future pull requests, there will be a need for being able to change the config temporarily as we run a `.profile`, so this change create that interface for allowing that to happen.

Currently nothing is hooked up and using this interface, and this just lays the ground work for it to be used in future commits.