### PR TITLE
Adds Memory MiddlewareStorage

### DIFF
--- a/lib/manageiq_performance/middleware.rb
+++ b/lib/manageiq_performance/middleware.rb
@@ -90,15 +90,24 @@ module ManageIQPerformance
     end
   end
 
-  def self.profile name = nil, &code
-    name ||= caller.first.match(/`(|.*\s)([a-z_\(\)]+)>?'$/)[2].gsub(/[^a-z_]/,'')
+  def self.profile *args, &code
+    options = args.last.is_a?(Hash) ? args.shift : {}
+    name    = args.shift
+    name    ||= caller.first.match(/`(|.*\s)([a-z_\(\)]+)>?'$/)[2].gsub(/[^a-z_]/,'')
+
     env  = {
       Middleware::PERFORMANCE_HEADER => true,
       "REQUEST_PATH"                 => name,
       "HTTP_MIQ_PERF_TIMESTAMP"      => (Time.now.to_f * 1000000).to_i
     }
 
-    ManageIQPerformance::Middleware.new(code).call(env)
+    if options[:config_changes]
+      ManageIQPerformance.with_config options[:config_changes] do
+        ManageIQPerformance::Middleware.new(code).call(env)
+      end
+    else
+      ManageIQPerformance::Middleware.new(code).call(env)
+    end
   end
 
 end

--- a/lib/manageiq_performance/middleware.rb
+++ b/lib/manageiq_performance/middleware.rb
@@ -101,8 +101,13 @@ module ManageIQPerformance
       "HTTP_MIQ_PERF_TIMESTAMP"      => (Time.now.to_f * 1000000).to_i
     }
 
-    if options[:config_changes]
-      ManageIQPerformance.with_config options[:config_changes] do
+    if options[:config_changes] || options[:in_memory]
+      config_changes = (options[:config_changes] || {}).dup
+      config_changes.merge!("middleware_storage" => %w[memory]) if options[:in_memory]
+    end
+
+    if config_changes
+      ManageIQPerformance.with_config config_changes do
         ManageIQPerformance::Middleware.new(code).call(env)
       end
     else

--- a/lib/manageiq_performance/middleware.rb
+++ b/lib/manageiq_performance/middleware.rb
@@ -101,16 +101,10 @@ module ManageIQPerformance
       "HTTP_MIQ_PERF_TIMESTAMP"      => (Time.now.to_f * 1000000).to_i
     }
 
-    if options[:config_changes] || options[:in_memory]
-      config_changes = (options[:config_changes] || {}).dup
-      config_changes.merge!("middleware_storage" => %w[memory]) if options[:in_memory]
-    end
+    config_changes = (options[:config_changes] || {}).dup
+    config_changes.merge!("middleware_storage" => %w[memory]) if options[:in_memory]
 
-    if config_changes
-      ManageIQPerformance.with_config config_changes do
-        ManageIQPerformance::Middleware.new(code).call(env)
-      end
-    else
+    ManageIQPerformance.with_config config_changes do
       ManageIQPerformance::Middleware.new(code).call(env)
     end
   end

--- a/lib/manageiq_performance/middleware_storage/memory.rb
+++ b/lib/manageiq_performance/middleware_storage/memory.rb
@@ -1,0 +1,35 @@
+module ManageIQPerformance
+  module MiddlewareStorage
+    class Memory
+      attr_reader :current_run, :profile_captures
+
+      def initialize
+        @current_run = {}
+        @profile_captures = []
+        ManageIQPerformance.last_run = nil
+      end
+
+      def record _, tag, __, data
+        @current_run[tag] = data.call
+      end
+
+      def finalize
+        @profile_captures << @current_run
+        ManageIQPerformance.last_run = @current_run
+        @current_run = {}
+      end
+    end
+  end
+
+  @memory_storage_mutex = Mutex.new
+  @memory_storage_mutex.synchronize { @last_run = nil }
+
+  def self.last_run= run_data
+    @memory_storage_mutex.synchronize { @last_run = run_data }
+  end
+
+  def self.last_run
+    @last_run
+  end
+
+end

--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -189,6 +189,61 @@ shared_examples "middleware functionality for" do |middleware_order|
         eval ProfilingTestClass.test_profile_eval_script
       end
     end
+
+    context "with the :config_changes option" do
+      before(:each) do
+        # Pre-require the middleware and middleware storages here incase they
+        # haven't been loaded via other parts of the suite.  In most cases,
+        # this will be wasteful, but the `Object.const_get` we have to do in
+        # the test farther down as a return result might get executed before
+        # any Middleware.new is called in the specs.
+        middleware_order.each do |name|
+          require "manageiq_performance/middlewares/#{name}"
+        end
+        ManageIQPerformance.config.middleware_storage.each do |name|
+          require "manageiq_performance/middleware_storage/#{name}"
+        end
+      end
+
+      # include one less middleware than what was passed into the example
+      let(:config_changes) { {"middleware" => middleware_order[0..-2].map(&:to_s) } }
+      let(:run_profile) do
+        Proc.new do
+          ManageIQPerformance.profile(:config_changes => config_changes) { work }
+        end
+      end
+
+      it "loads the config changed middleware in order" do
+        # Confirms that we load the reduced set of middleware that changes with
+        # the config_changes
+        #
+        # Need to include the configured middleware storages in here as well
+        # since they share the usage of `Object.const_get`, and we have to do
+        # these both these prior to the `expect().to recieve` calls, otherwise
+        # the spec will fail early.
+        (middleware_order[0..-2].map { |name|
+          constant_name = "ManageIQPerformance::Middlewares::#{name.to_s.split("_").map(&:capitalize).join}"
+          constant      = Object.const_get constant_name
+          [constant_name, constant]
+        } + ManageIQPerformance.config.middleware_storage.map { |name|
+          constant_name = "ManageIQPerformance::MiddlewareStorage::#{name.to_s.split("_").map(&:capitalize).join}"
+          constant      = Object.const_get constant_name
+          [constant_name, constant]
+        }).each do |constant_name, constant|
+          expect(Object).to receive(:const_get).with(constant_name).and_return(constant)
+        end
+
+        unused_middleware = "ManageIQPerformance::Middlewares::#{middleware_order.last.to_s.split("_").map(&:capitalize).join}"
+        expect(Object).to receive(:const_get).with(unused_middleware).never
+
+        run_profile.call
+      end
+
+      it "returns the result of the block" do
+        ManageIQPerformance.profile(:config_changes => config_changes) { Thread.current[:result] = 42 }
+        expect(Thread.current[:result]).to eq(42)
+      end
+    end
   end
 
   after do

--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -244,10 +244,24 @@ shared_examples "middleware functionality for" do |middleware_order|
         expect(Thread.current[:result]).to eq(42)
       end
     end
+
+    context "with :in_memory set" do
+      let(:in_memory_config) { { "middleware_storage" => %w[memory] } }
+      it "runs with a temporary configuration" do
+        expect(ManageIQPerformance).to receive(:with_config).with(in_memory_config)
+        ManageIQPerformance.profile(:in_memory => true) { work }
+      end
+
+      it "doesn't clobber other config changes" do
+        config_changes = {"middleware" => [] }
+        expect(ManageIQPerformance).to receive(:with_config).with(config_changes.merge in_memory_config)
+        ManageIQPerformance.profile(:in_memory => true, :config_changes => config_changes) { work }
+      end
+    end
   end
 
   after do
-    FileUtils.rm_r ManageIQPerformance.config.default_dir
+    FileUtils.rm_rf ManageIQPerformance.config.default_dir
   end
 end
 

--- a/spec/manageiq_performance/middleware_storage/memory_spec.rb
+++ b/spec/manageiq_performance/middleware_storage/memory_spec.rb
@@ -1,0 +1,55 @@
+require "manageiq_performance/middleware_storage/memory"
+
+describe ManageIQPerformance::MiddlewareStorage::Memory do
+  let(:env)         { {} }
+  let(:data)        { { :sql_queries => %w[Query1 Query2] } }
+  let(:data_writer) { Proc.new { data } }
+
+  describe "#initialize" do
+    # Make sure the subject is initialized in each spec to reset last_run
+    before(:each) { subject }
+
+    it "setups a 'profile_captures' object" do
+      expect(subject.profile_captures).to eq []
+    end
+
+    it "resets the ManageIQPerformance.last_run" do
+      expect(ManageIQPerformance.last_run).to eq nil
+    end
+  end
+
+  describe "#record" do
+    it "stores the data from the record in a nested hash" do
+      subject.record env, :sql, nil, data_writer
+      expect(subject.current_run[:sql]).to eq data
+    end
+  end
+
+  describe "finalize" do
+    let(:data2) { { :sql_queries => %w[Query3 Query4 Query5] } }
+
+    before(:each) do
+      subject.record env, :sql, nil, data_writer
+      subject.finalize
+    end
+
+    it "adds the current_run to the profile_captures" do
+      expect(subject.profile_captures).to eq [{:sql => data}]
+    end
+
+    it "sets last_run to current_run" do
+      result = {:sql => data}
+      expect(ManageIQPerformance.last_run).to eq result
+    end
+
+    it "resets the current_run" do
+      expect(subject.current_run).to eq Hash.new
+    end
+
+    it "stores subsequent runs as well" do
+      subject.record env, :sql, nil, Proc.new { data2 }
+      subject.finalize
+      expect(subject.profile_captures).to eq [{:sql => data}, {:sql => data2}]
+    end
+  end
+end


### PR DESCRIPTION
This is meant to me a quick access storage when using the `.profile` method, and is not retained after the process is ended.  Because of that, this storage is not part of the defaults.  This MiddlewareStorage does however provide top level mechanisms for viewing the `last_run` for the most recent `.profile`, allowing you to access the gathered data from a script or while using it in `irb`.

Options were also added to the `.profile` method:

* The `:config_changes` option adds the ability to update the `ManageIQPerformance::Configuration` for the duration of the `.profile` method, and return it after.  This merges the existing configuration instead of starting from scratch.
* `:in_memory` can be used as a short hand for enabling the memory storage for a profile run, and effectively is a `:config_changes` to use just the memory storage for the middleware storages configuration.  This works in conjunction with `:config_changes`, though this option takes precedence of the `"middleware_storage"` config changes.

This PR is based off of changes in https://github.com/ManageIQ/manageiq-performance/pull/28