### PR TITLE
Use Timecop to prevent non-deterministic failures

### DIFF
--- a/manageiq-performance.gemspec
+++ b/manageiq-performance.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "stackprof"
   spec.add_development_dependency "rails"
+  spec.add_development_dependency "timecop"
 end


### PR DESCRIPTION
When testing the GemBase64 class, we compare the build of the gem through normal means (building a gem and writing it to a file), and how it is used in the GemBase64 class, which is saved to a StringIO object in memory.

When the gem is tar'd up, it ends up (I assume) writing some timestamps to the file, or some MD5SUMs (again, I assume that uses a timestamp in the algorithm), which can cause differences in the output of the `.gem` file and the `StringIO` outputs on occasion.

By using `Timecop`, this has completely prevented the issue from showing up, unlike in master where this seems to break the tests every 5 runs or so.


To QA this change locally
-------------------------
1. Checkout master.
2. Run the following:  `echo; while [ $? == 0 ]; do rspec; done;`
3. It should fail within 20 runs or so.
4. Checkout these changes.
5. Repeat step 2
6. There should be no failures anymore

Note: To kill the loop, you will probably want to open up the `spec/tasks/support/gem_base64_spec.rb` file and inject a `fail` line somewhere in there to make it easier to have the process die.  Any spec file will do though, you just need to inject a `exit 1` somewhere.