### PR TITLE
Bugfix: Use .pop instead of .shift for args in ManageIQPerformance.profile when setting options

### DIFF
--- a/lib/manageiq_performance/middleware.rb
+++ b/lib/manageiq_performance/middleware.rb
@@ -91,7 +91,7 @@ module ManageIQPerformance
   end
 
   def self.profile *args, &code
-    options = args.last.is_a?(Hash) ? args.shift : {}
+    options = args.last.is_a?(Hash) ? args.pop : {}
     name    = args.shift
     name    ||= caller.first.match(/`(|.*\s)([a-z_\(\)]+)>?'$/)[2].gsub(/[^a-z_]/,'')
 

--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -243,6 +243,11 @@ shared_examples "middleware functionality for" do |middleware_order|
         ManageIQPerformance.profile(:config_changes => config_changes) { Thread.current[:result] = 42 }
         expect(Thread.current[:result]).to eq(42)
       end
+
+      it "allows still setting a name for the profile block" do
+        ManageIQPerformance.profile("my_name", :config_changes => config_changes) { Thread.current[:result] = 42 }
+        expect(Thread.current[:result]).to eq(42)
+      end
     end
 
     context "with :in_memory set" do


### PR DESCRIPTION
Fixes the incorrect arg getting removed from the splat args in `ManageIQPerformance.profile` and setting options to the incorrect value.

This bug only presents itself if you also pass in a `name` into the `.profile` call, otherwise it has silently worked in the tests.  A spec has been added to make sure this doesn't fail in the future.