### PR TITLE
[WIP] Adds MiqQueue profiling

### DIFF
--- a/lib/manageiq_performance/configuration.rb
+++ b/lib/manageiq_performance/configuration.rb
@@ -34,7 +34,8 @@ module ManageIQPerformance
         memory
       ],
       "middleware_storage"   => %w[file],
-      "browser_mode"  => {
+      "monitor_queue"        => false,
+      "browser_mode"         => {
         "enabled"   => false,
         "always_on" => false
       }
@@ -91,6 +92,11 @@ module ManageIQPerformance
     def include_memsize?
       self["include_memsize"]
     end
+
+    def monitor_queue?
+      self["monitor_queue"]
+    end
+
     def stacktrace_cleaner
       @stacktrace_cleaner ||=
         begin

--- a/lib/manageiq_performance/middlewares/miq_queue_timers.rb
+++ b/lib/manageiq_performance/middlewares/miq_queue_timers.rb
@@ -1,0 +1,93 @@
+begin
+  # Autoload MiqQueue
+  ::MiqQueue
+
+  # Monkey Patch MiqQueue
+  class ::MiqQueue < ApplicationRecord
+    alias original_deliver deliver
+
+    # Effectively wraps MiqQueue in a ManageIQPerformance.profile block, and
+    # runs that normally.
+    def deliver(requester = nil)
+      name  = class_name
+      name += ".find(#{instance_id})" if instance_id
+      name += ".#{method_name}"
+
+      # Remove any middleware that don't make sense to use with this
+      # middleware:
+      tmp_middleware  = ManageIQPerformance.config.middleware.reject do |mw|
+        ManageIQPerformance::Middlewares::MiqQueueTimers::CONFLICTING_MIDDLEWARE.include?(mw)
+      end
+      changes = {"middleware" => tmp_middleware + ["miq_queue_timers"] }
+
+      ManageIQPerformance.profile(name, :config_changes => changes) {
+        original_deliver(requester)
+      }
+    end
+  end
+
+  module ManageIQPerformance
+    module Middlewares
+      module MiqQueueTimers
+
+        CONFLICTING_MIDDLEWARE = %w[active_support_timers]
+
+        private
+
+        def miq_queue_timers_initialize; end
+
+        # no-op since this is simply making use of the ENV that is set by
+        # ManageIQPerformance.profile
+        def miq_queue_timers_start(env); end
+
+        def miq_queue_timers_finish(env)
+          if env["HTTP_MIQ_PERF_TIMESTAMP"]
+            time = (env["MIQ_PERFORMANCE_END_TIME"].to_i - env["HTTP_MIQ_PERF_TIMESTAMP"].to_i) / 1000
+            Thread.current[:miq_perf_queue_timer_data] = {
+              "item" => env["REQUEST_PATH"],
+              "time" => time
+            }
+          end
+
+          if Thread.current[:miq_perf_queue_timer_data]
+            save_report env, :queue_info,
+                        miq_queue_timers_short_form_data,
+                        miq_queue_timers_long_form_data
+          end
+        ensure
+          Thread.current[:miq_perf_queue_timer_data] = nil
+        end
+
+        def miq_queue_timers_long_form_data
+          proc {
+            class_name, *parts = Thread.current[:miq_perf_queue_timer_data]["item"].split(".")
+            method_name        = parts.first if parts.size == 1
+            instance_id, method_name = parts if parts.size == 2
+            {
+              "pid"         => Process.pid,
+              "class_name"  => class_name,
+              "method_name" => method_name,
+              # remove "find(...)" in the "find(<<ID>>)", leaving <<ID>>
+              "instance_id" => instance_id && instance_id.to_s[5..-2].to_i,
+              "total_time"  => Thread.current[:miq_perf_queue_timer_data]["time"]
+            }
+          }
+        end
+
+        def miq_queue_timers_short_form_data
+          proc do
+            {
+              "queue_item" => Thread.current[:miq_perf_queue_timer_data]["item"],
+              "pid"        => Process.pid,
+              "total_time" => Thread.current[:miq_perf_queue_timer_data]["time"]
+            }
+          end
+        end
+      end
+    end
+  end
+
+rescue NameError
+  # No-Op:  This probably means that MiqQueue is not defined, so lets move on
+  # as if it hasn't been.
+end

--- a/lib/manageiq_performance/railtie/middleware.rb
+++ b/lib/manageiq_performance/railtie/middleware.rb
@@ -12,5 +12,11 @@ module ManageIQPerformance
         app.middleware.insert_before "ManageIQPerformance::Middleware", "ManageIQPerformance::BrowserModeMiddleware"
       end
     end
+
+    if ManageIQPerformance.config.monitor_queue?
+      config.after_initialize do
+        require "manageiq_performance/middlewares/miq_queue_timers"
+      end
+    end
   end
 end

--- a/spec/manageiq_performance/configuration_spec.rb
+++ b/spec/manageiq_performance/configuration_spec.rb
@@ -26,6 +26,7 @@ shared_examples "the default config" do |config_options={}|
     ["requestor", "requestfile_dir"] => nil,
     ["middleware"]                   => %w[stackprof active_support_timers active_record_queries memory],
     ["middleware_storage"]           => %w[file],
+    ["monitor_queue?"]               => false,
     ["browser_mode", "enabled?"]     => false,
     ["browser_mode", "always_on?"]   => false,
   }
@@ -185,6 +186,7 @@ describe ManageIQPerformance::Configuration do
         middleware_storage:
           - file
           - log
+        monitor_queue: true
         browser_mode:
           enabled: true
           always_on: true
@@ -269,6 +271,11 @@ describe ManageIQPerformance::Configuration do
       middleware_storage = %w[file log]
       expect(ManageIQPerformance.config.middleware_storage).to eq middleware_storage
       expect(ManageIQPerformance.config["middleware_storage"]).to eq middleware_storage
+    end
+
+    it "defines ManageIQPerformance.config.monitor_queue?" do
+      expect(ManageIQPerformance.config.monitor_queue?).to eq true
+      expect(ManageIQPerformance.config["monitor_queue"]).to eq true
     end
 
     it "defines ManageIQPerformance.config.browser_mode.enabled?" do


### PR DESCRIPTION
Adds the following:

* New setting:  `ManageIQPerformance.config.monitor_queue?`
* New middleware:  `ManageIQPerformance::Middlewares::MiqQueueTimers`

The new setting, off by default, wraps the `MiqQueue#deliver` method in a `ManageIQPerformance.profile` when enabled.  This will also make sure to include the `ManageIQPerformance::Middlewares::MiqQueueTimers`, which is similar to the `ActiveSupportTimers`, and does a few things to add simple info about the queue job being profiled.  This works in conjunction with the monkey patch to `MiqQueue` to allow this info to be captured.

TODO
----
* [ ] Add some tests around this