### PR TITLE
Fixes and tweaks to requires in CLI (miqperf)

### DIFF
--- a/lib/manageiq_performance/commands/analyze.rb
+++ b/lib/manageiq_performance/commands/analyze.rb
@@ -34,6 +34,8 @@ begin
         private
 
         def option_parser
+          require "optparse"
+
           @optparse ||= OptionParser.new do |opt|
             opt.banner = "Usage: #{File.basename $0} analyze [options] [dir]"
 

--- a/lib/manageiq_performance/commands/analyze.rb
+++ b/lib/manageiq_performance/commands/analyze.rb
@@ -1,6 +1,6 @@
-require "manageiq_performance/configuration"
-
 begin
+  # Have this up top so we don't initialize this class if the stackprof dep
+  # isn't available.
   require "stackprof"
 
   module ManageIQPerformance
@@ -11,6 +11,8 @@ begin
         end
 
         def self.run(args)
+          require "manageiq_performance/configuration"
+
           new(args).run
         end
 

--- a/lib/manageiq_performance/commands/benchmark.rb
+++ b/lib/manageiq_performance/commands/benchmark.rb
@@ -50,6 +50,8 @@ module ManageIQPerformance
       end
 
       def option_parser
+        require "optparse"
+
         @optparse ||= OptionParser.new do |opt|
           opt.banner = "Usage: #{File.basename $0} benchmark [options] path"
 

--- a/lib/manageiq_performance/commands/benchmark.rb
+++ b/lib/manageiq_performance/commands/benchmark.rb
@@ -1,7 +1,3 @@
-require "manageiq_performance/configuration"
-require "manageiq_performance/requestor"
-require "manageiq_performance/reporting/requestfile_builder"
-
 module ManageIQPerformance
   module Commands
     class Benchmark
@@ -10,6 +6,10 @@ module ManageIQPerformance
       end
 
       def self.run(args)
+        require "manageiq_performance/configuration"
+        require "manageiq_performance/requestor"
+        require "manageiq_performance/reporting/requestfile_builder"
+
         new(args).run
       end
 

--- a/lib/manageiq_performance/commands/clean.rb
+++ b/lib/manageiq_performance/commands/clean.rb
@@ -1,4 +1,3 @@
-require "optparse"
 require "fileutils"
 require "manageiq_performance/configuration"
 
@@ -32,6 +31,8 @@ module ManageIQPerformance
       private
 
       def option_parser
+        require "optparse"
+
         OptionParser.new do |opt|
           opt.banner = "Usage: #{File.basename $0} clean [options]"
 

--- a/lib/manageiq_performance/commands/clean.rb
+++ b/lib/manageiq_performance/commands/clean.rb
@@ -1,6 +1,3 @@
-require "fileutils"
-require "manageiq_performance/configuration"
-
 module ManageIQPerformance
   module Commands
     class Clean
@@ -11,6 +8,9 @@ module ManageIQPerformance
       end
 
       def self.run(args)
+        require "fileutils"
+        require "manageiq_performance/configuration"
+
         new(args).run
       end
 

--- a/lib/manageiq_performance/commands/report.rb
+++ b/lib/manageiq_performance/commands/report.rb
@@ -1,6 +1,3 @@
-require "manageiq_performance/configuration"
-require "manageiq_performance/reporter"
-
 module ManageIQPerformance
   module Commands
     class Report
@@ -9,6 +6,9 @@ module ManageIQPerformance
       end
 
       def self.run(args)
+        require "manageiq_performance/configuration"
+        require "manageiq_performance/reporter"
+
         new(args).run
       end
 

--- a/lib/manageiq_performance/commands/report.rb
+++ b/lib/manageiq_performance/commands/report.rb
@@ -25,6 +25,8 @@ module ManageIQPerformance
       private
 
       def option_parser
+        require "optparse"
+
         @optparse ||= OptionParser.new do |opt|
           opt.banner = "Usage: #{File.basename $0} report [options] [dir]"
 


### PR DESCRIPTION
1.  `OptionParser` was not required in almost all of the command files (I seriously have no idea how this was working perviously...)
2.  Deferred the requires of `'optparse'` to the `#option_parser` instance method of each command
3.  Deferred the requires of any other files needed by a specific command to the `.run` method (speeds up the `help` command)