### PR TITLE
Adds --api flag to miq_perf

### DIFF
--- a/lib/manageiq_performance/commands/benchmark.rb
+++ b/lib/manageiq_performance/commands/benchmark.rb
@@ -14,7 +14,7 @@ module ManageIQPerformance
       end
 
       def initialize(args)
-        @opts     = {:samples => 1}
+        @opts     = {:samples => 1, :api => false}
         parse_env_variables
         option_parser.parse!(args)
         @path     = args.first
@@ -68,6 +68,7 @@ module ManageIQPerformance
           opt.separator ""
           opt.separator "Options"
 
+          opt.on("-a",     "--[no-]api",           "Toggle api requests",    set_api)
           opt.on("-HHOST", "--host=HOST",          "MIQ endpoint to target", define_host)
           opt.on("-mMETH", "--method=METHOD",      "HTTP method (def: GET)", http_method)
           opt.on("-d",     "--no-ssl",             "Disable SSL verify",     disable_ssl)
@@ -76,6 +77,10 @@ module ManageIQPerformance
           opt.on("-sNUM",  "--samples=NUM",        "Alias for --count",      set_count)
           opt.on("-h",     "--help",               "Show this message") { puts opt; exit }
         end
+      end
+
+      def set_api
+        Proc.new {|api| @opts[:api] = api }
       end
 
       def define_host

--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -30,6 +30,8 @@ module ManageIQPerformance
       @logger      = options[:logger] || Logger.new(STDOUT)
       @ignore_cert = options[:ignore_ssl] || false
 
+      require 'json' if api
+
       login
     end
 
@@ -48,13 +50,17 @@ module ManageIQPerformance
       request_args  = Array(payload)
       request_args << (options[:headers] || full_request_headers)
 
-      unless %w[/ /dashboard/authenticate].include?(path) # logged already
+      unless %w[/ /api/auth /dashboard/authenticate].include?(path) # logged already
         log "--> making #{method.to_s.upcase} request: #{path}"
       end
 
       http.send(method, path, *request_args).tap do |response|
-        set_cookie_field = response.get_fields('set-cookie')
-        @session         = set_cookie_field[0] if set_cookie_field
+        if api && path == '/api/auth'
+          @session         = JSON.parse(response.body)["auth_token"]
+        elsif not api
+          set_cookie_field = response.get_fields('set-cookie')
+          @session         = set_cookie_field[0] if set_cookie_field
+        end
       end
     end
 
@@ -69,8 +75,12 @@ module ManageIQPerformance
     def login
       hdrs = login_headers
       log "--> logging in..."
-      nethttp_request :post, "/dashboard/authenticate",
-                  :params  => credentials, :headers => hdrs
+      if api
+        nethttp_request :get, "/api/auth", :headers => hdrs
+      else
+        nethttp_request :post, "/dashboard/authenticate",
+                        :params  => credentials, :headers => hdrs
+      end
     end
 
     def csrf_token
@@ -81,16 +91,26 @@ module ManageIQPerformance
     end
 
     def login_headers
-      HTML_HEADERS.merge({
-        'X-CSRF-Token' => csrf_token.to_s, # first so session is set correctly
-        'Cookie'       => @session,
-      })
+      if api
+        JSON_HEADERS.merge({
+          # Value calculated from the same method found in
+          # Net::HTTPHeader#basic_encode, which is what is used in the
+          # `#basic_auth` method.
+          'authorization' => 'Basic ' + ["#{username}:#{password}"].pack('m0')
+        })
+      else
+        HTML_HEADERS.merge({
+          'X-CSRF-Token' => csrf_token.to_s, # first so session is set correctly
+          'Cookie'       => @session,
+        })
+      end
     end
 
     def full_request_headers
       timestamp = (Time.now.to_f * 1000000).to_i.to_s
+      token_hdr = api ? "X-Auth-Token" : "Cookie"
       @headers.merge({
-        'Cookie'             => @session,
+        token_hdr            => @session,
         'MIQ_PERF_TIMESTAMP' => timestamp
       })
     end

--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -13,11 +13,12 @@ module ManageIQPerformance
                          'MIQ_PERF_STACKPROF_RAW' => 'true'
                        }.merge(BASE_HEADERS)
 
-    attr_accessor :uri, :session, :headers
+    attr_accessor :uri, :api, :session, :headers
 
     def initialize(options={})
       @uri         = URI.parse(options[:host] || "http://localhost:3000")
       @headers     = DEFAULT_HEADERS.merge(options[:headers] || {})
+      @api         = options[:api] || false
       @logger      = options[:logger] || Logger.new(STDOUT)
       @ignore_cert = options[:ignore_ssl] || false
 


### PR DESCRIPTION
Allows for benchmarking the API in the same way that you would with `miqperf benchmark`.

+ Adds flag to CLI to denote this is an API request
+ Updates request headers to support API based requests
  - Deprecates the previous header constants in the process
+ Changes login flow when `--api` is present