### PR TITLE
Add many missing (and needed) middleware specs

### DIFF
--- a/lib/manageiq_performance/middlewares/active_record_queries.rb
+++ b/lib/manageiq_performance/middlewares/active_record_queries.rb
@@ -159,6 +159,23 @@ module ManageIQPerformance
         end
       end
 
+      def self.clear_memoized_logger_vars
+        %w(sql.active_record instantiation.active_record).each do |event|
+          listeners = ActiveSupport::Notifications.notifier.listeners_for(event)
+          logger    = listeners.detect do |l|
+            l.instance_variable_get(:@delegate).is_a? self::Logger
+          end.instance_variable_get(:@delegate)
+
+          [
+            :@include_queries, :@include_trace, :@skip_schema_queries
+          ].each do |instance_variable|
+            if logger.instance_variable_defined? instance_variable
+              logger.remove_instance_variable instance_variable
+            end
+          end
+        end
+      end
+
     end
   end
 end

--- a/lib/manageiq_performance/middlewares/active_record_queries.rb
+++ b/lib/manageiq_performance/middlewares/active_record_queries.rb
@@ -153,7 +153,7 @@ module ManageIQPerformance
         IGNORED_PAYLOAD    = %w[EXPLAIN CACHE].freeze
 
         def ignore_payload?(payload)
-          payload[:exception] ||
+          payload[:exception] || payload[:cached] ||
           (skip_schema_queries? and SCHEMA_QUERY_TYPES.include?(payload[:name])) ||
           IGNORED_PAYLOAD.include?(payload[:name])
         end

--- a/manageiq-performance.gemspec
+++ b/manageiq-performance.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "stackprof"
   spec.add_development_dependency "rails"
+  spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "rake-compiler-dock", "~> 0.6.1"
 end

--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -91,9 +91,22 @@ shared_examples "middleware functionality for" do |middleware_order|
 
     it "finishes the middleware in reverse order" do
       allow(subject).to receive(:performance_middleware_start)
+      middleware_order.each do |name|
+        allow(subject).to receive("#{name}_start")
+      end
 
       middleware_order.reverse.each do |name|
         expect(subject).to receive("#{name}_finish").ordered
+      end
+
+      subject.call(basic_env)
+    end
+
+    it "calls `#finalize` on each of the middleware storages" do
+      allow(subject).to receive(:performance_middleware_start)
+
+      subject.middleware_storage.each do |storage|
+        expect(storage).to receive(:finalize).ordered
       end
 
       subject.call(basic_env)

--- a/spec/manageiq_performance/middleware_spec.rb
+++ b/spec/manageiq_performance/middleware_spec.rb
@@ -135,8 +135,8 @@ shared_examples "middleware functionality for" do |middleware_order|
       end
     end
 
-    # Testing that when a name is given, we are creating a name based on the
-    # call stack something that only has letters and underscores for the
+    # Testing that when a name is not given, we are creating a name based on
+    # the call stack something that only has letters and underscores for the
     # generated filename.  Don't really want to create another method for this,
     # but this is some dense regexp code that is being done to generate this
     # name.

--- a/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
+++ b/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
@@ -121,6 +121,21 @@ describe ManageIQPerformance::Middlewares::ActiveRecordQueries do
       expect(data[:total_queries]).to              be nil
     end
 
+    it "ignores cached queries" do
+      BaseClass.cache do
+        query_1.load
+        Book.where(:id => 1).load # query that will be cached
+      end
+
+      expect(data[:queries].count).to              eq 1
+      expect(data[:queries].first[:sql]).to        eq query_1_result
+      expect(data[:queries].first[:params]).to     eq [["id", "1"]]
+      expect(data[:queries].first[:stacktrace]).to be nil
+      expect(data[:rows_by_class]["Book"]).to      eq 0
+      expect(data[:total_queries]).to              eq 1
+      expect(data[:total_rows]).to                 eq 0
+    end
+
     it "ignores SCHEMA queries" do
       BaseClass.connection.table_exists?("books")
       BaseClass.connection.table_exists?("authors")

--- a/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
+++ b/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
@@ -20,13 +20,17 @@ class FakeQueriesMiddleware
   private
 
   def save_report(env, type, short, long)
-    # no-op for now
+    if env[:short]
+      env[:output].puts short.call.to_json
+    else
+      env[:output].write YAML.dump(long.call)
+    end
   end
 end
 
 describe ManageIQPerformance::Middlewares::ActiveRecordQueries do
   subject              { FakeQueriesMiddleware.new }
-  let(:env)            { {} }
+  let(:env)            { { :output => StringIO.new, :short => false } }
   let(:query_1)        { Book.where(:id => 1) }
   let(:query_1_result) {
     <<-QUERY.split("\n").map(&:strip).join ' '
@@ -71,6 +75,168 @@ describe ManageIQPerformance::Middlewares::ActiveRecordQueries do
 
       logger_class = ::ManageIQPerformance::Middlewares::ActiveRecordQueries::Logger
       expect( existing_notifiers.select {|n| n == logger_class }.count ).to eq(1)
+    end
+  end
+
+  describe "#start (private)", :with_active_record do
+    before     { subject.start env }
+    after      { subject.finish env }
+    let(:data) { Thread.current[:miq_perf_sql_query_data] }
+
+    it "initalizes thread data" do
+      expect(data).to eq({
+        :queries       => [],
+        :rows_by_class => {}
+      })
+    end
+
+    it "keeps track of the stored queries" do
+      query_1.load
+
+      expect(data[:queries].count).to              eq 1
+      expect(data[:queries].first[:sql]).to        eq query_1_result
+      expect(data[:queries].first[:params]).to     eq [["id", "1"]]
+      expect(data[:queries].first[:stacktrace]).to be nil
+      expect(data[:rows_by_class]["Book"]).to      eq 0
+      expect(data[:total_queries]).to              eq 1
+      expect(data[:total_rows]).to                 eq 0
+    end
+
+    it "skips failed queries" do
+      begin
+        Book.connection.execute "SELECT * FROM articles"
+      rescue ActiveRecord::StatementInvalid
+      end
+
+      expect(data[:queries].count).to              eq 0
+      expect(data[:rows_by_class].empty?).to       be true
+      expect(data[:total_queries]).to              be nil
+    end
+
+    it "ignores EXPLAIN queries" do
+      Book.connection.explain Book.all.to_sql
+
+      expect(data[:queries].count).to              eq 0
+      expect(data[:rows_by_class].empty?).to       be true
+      expect(data[:total_queries]).to              be nil
+    end
+
+    it "ignores SCHEMA queries" do
+      BaseClass.connection.table_exists?("books")
+      BaseClass.connection.table_exists?("authors")
+
+      expect(data[:queries].count).to              eq 0
+      expect(data[:rows_by_class].empty?).to       be true
+      expect(data[:total_queries]).to              be nil
+    end
+
+    context "if config.skip_schema_queries? false" do
+      it "includes SCHEMA queries" do
+        # Get currently configured logger
+        logger = fetch_logger_for 'sql.active_record'
+
+        # Unset configured `skip_schema_queries` setting
+        if logger.instance_variable_defined? :@skip_schema_queries
+          logger.remove_instance_variable :@skip_schema_queries
+        end
+
+        # Run SCHEMA queries
+        ManageIQPerformance.with_config('skip_schema_queries' => false) do
+          BaseClass.connection.table_exists?("books")
+          BaseClass.connection.table_exists?("authors")
+        end
+
+        # Clear temporary setting
+        logger.remove_instance_variable :@skip_schema_queries
+
+        expect(data[:queries].count).to            eq 2
+        expect(data[:rows_by_class].empty?).to     be true
+        expect(data[:total_queries]).to            be 2
+      end
+    end
+
+    context "if config.include_sql_queries? is false" do
+      it "doesn't include query info" do
+        # Get currently configured logger
+        logger = fetch_logger_for 'sql.active_record'
+
+        # Unset configured `include_sql_queries` setting
+        if logger.instance_variable_defined? :@include_queries
+          logger.remove_instance_variable :@include_queries
+        end
+
+        # Run queries
+        ManageIQPerformance.with_config('include_sql_queries' => false) do
+          query_1.load
+        end
+
+        # Clear temporary setting
+        logger.remove_instance_variable :@include_queries
+
+        expect(data[:queries].count).to            eq 0
+        expect(data[:rows_by_class]["Book"]).to    eq 0
+        expect(data[:total_queries]).to            eq 1
+        expect(data[:total_rows]).to               eq 0
+      end
+    end
+
+    context "if config.include_stack_traces? is true" do
+      it "includes stacktraces of sql queries" do
+        # Get currently configured logger
+        logger = fetch_logger_for 'sql.active_record'
+
+        # Unset configured `include_stack_traces` setting
+        if logger.instance_variable_defined? :@include_trace
+          logger.remove_instance_variable :@include_trace
+        end
+
+        # Run queries
+        ManageIQPerformance.with_config('include_stack_traces' => true) do
+          query_1.load
+        end
+
+        # Clear temporary setting
+        logger.remove_instance_variable :@include_trace
+
+        actual_stacktrace = data[:queries].first[:stacktrace]
+        this_file_name    = __FILE__.sub(/.*\/(spec.*)/, '\1')
+        expect(actual_stacktrace.first).to include this_file_name
+      end
+    end
+  end
+
+  describe "#finish (private)", :with_active_record do
+    before do
+      subject.start env
+      query_1.load
+      subject.finish env
+    end
+
+    it "saves the report" do
+      data = YAML.load env[:output].tap(&:rewind)
+
+      expect(data[:queries].count).to              eq 1
+      expect(data[:queries].first[:sql]).to        eq query_1_result
+      expect(data[:queries].first[:params]).to     eq [["id", "1"]]
+      expect(data[:queries].first[:stacktrace]).to be nil
+      expect(data[:rows_by_class]["Book"]).to      eq 0
+      expect(data[:total_queries]).to              eq 1
+      expect(data[:total_rows]).to                 eq 0
+    end
+
+    it "clears Thread.current[:miq_perf_sql_query_data]" do
+      expect(Thread.current[:miq_perf_sql_query_data]).to be nil
+    end
+
+    context "with the short form configured in the env" do
+      let(:env) { { :output => StringIO.new, :short => true } }
+
+      it "saves the report with the short form data" do
+        data = JSON.parse env[:output].tap(&:rewind).each_line.first
+
+        expect(data['queries']).to eq 1
+        expect(data['rows']).to    eq 0
+      end
     end
   end
 

--- a/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
+++ b/spec/manageiq_performance/middlewares/active_record_queries_spec.rb
@@ -1,4 +1,4 @@
-require "active_record"
+require "support/contexts/with_active_record"
 require "manageiq_performance/middleware"
 require "manageiq_performance/middlewares/active_record_queries"
 
@@ -8,9 +8,48 @@ class FakeQueriesMiddleware
   def initialize
     active_record_queries_initialize
   end
+
+  def start env
+    active_record_queries_start env
+  end
+
+  def finish env
+    active_record_queries_finish env
+  end
+
+  private
+
+  def save_report(env, type, short, long)
+    # no-op for now
+  end
 end
 
 describe ManageIQPerformance::Middlewares::ActiveRecordQueries do
+  subject              { FakeQueriesMiddleware.new }
+  let(:env)            { {} }
+  let(:query_1)        { Book.where(:id => 1) }
+  let(:query_1_result) {
+    <<-QUERY.split("\n").map(&:strip).join ' '
+      SELECT "books".*
+      FROM "books"
+      WHERE "books"."id" = ?
+    QUERY
+  }
+
+  describe ".clear_memoized_logger_vars", :with_active_record do
+    it "clears vars on any attached logger instances" do
+      subject.start  env
+      query_1.load
+      subject.finish env
+      described_class.clear_memoized_logger_vars
+
+      logger = fetch_logger_for 'sql.active_record'
+      expect(logger.instance_variable_defined? :@skip_schema_queries).to be false
+      expect(logger.instance_variable_defined? :@include_queries).to     be false
+      expect(logger.instance_variable_defined? :@include_trace).to       be false
+    end
+  end
+
   context "with more than one instance of the middleware" do
     before(:each) do
       2.times { FakeQueriesMiddleware.new }
@@ -33,5 +72,11 @@ describe ManageIQPerformance::Middlewares::ActiveRecordQueries do
       logger_class = ::ManageIQPerformance::Middlewares::ActiveRecordQueries::Logger
       expect( existing_notifiers.select {|n| n == logger_class }.count ).to eq(1)
     end
+  end
+
+  def fetch_logger_for event
+    ActiveSupport::Notifications.notifier.listeners_for(event).detect do |l|
+      l.instance_variable_get(:@delegate).is_a? described_class::Logger
+    end.instance_variable_get(:@delegate)
   end
 end

--- a/spec/support/active_record/base_class.rb
+++ b/spec/support/active_record/base_class.rb
@@ -1,0 +1,17 @@
+require "active_support/core_ext/kernel/reporting"
+
+class BaseClass < ActiveRecord::Base
+  self.abstract_class = true
+
+  self.configurations = ActiveRecord::Base.configurations
+  establish_connection :default
+
+  # HACK:  not sure the #RightWay™ to do this
+  Kernel.silence_warnings do
+    def self.id_increment
+      @id_increment ||= 0
+      @id_increment  += 1
+    end
+  end
+end
+

--- a/spec/support/contexts/with_active_record.rb
+++ b/spec/support/contexts/with_active_record.rb
@@ -1,0 +1,115 @@
+require 'active_record'
+
+configurations = {
+  'default' => {
+    'adapter'  => 'sqlite3',
+    'database' => ':memory:'
+  }
+}
+ActiveRecord::Base.configurations = configurations
+ActiveRecord::Base.establish_connection :default
+
+##
+# Creates a database schema for the test, in memory, builds up models, and
+# removes them once finished.
+#
+# Example:
+#
+#  ```
+#  describe "Book#where", :with_active_record_schema
+#  end
+#  ```
+#
+shared_context 'with active_record', :with_active_record do
+  before(:all) { active_record_setup }
+  after(:all)  { active_record_teardown }
+
+  private
+
+  def active_record_setup
+    create_base_class
+    create_schema_and_models
+  end
+
+  def active_record_teardown
+    BaseClass.remove_connection
+    remove_ar_model_classes
+  end
+
+  def create_base_class
+    # Can't use an abstract object here with Object.const_set I guess, since it
+    # doesn't work will with the `self.abstract_class = true`.
+    load_class "base_class"
+  end
+
+  # Calling load should always execute the code in the file and the constant
+  # is removed as part of an `after` block.
+  def load_class class_underscore
+    root = File.dirname __FILE__
+    file = "#{class_underscore}.rb"
+    load File.expand_path File.join("..", "active_record", file), root
+  end
+
+  def create_schema_and_models
+    # Define schema
+    this = self
+    ActiveRecord::Schema.define do
+      self.verbose = false
+
+      def self.connection
+        BaseClass.connection
+      end
+
+      def self.set_pk_sequence!(*); end
+
+      create_table :authors, &this.send(:_author_schema)
+      create_table :books, &this.send(:_book_schema)
+    end
+
+    _author_model_create
+    _book_model_create
+  end
+
+  def _author_schema
+    proc do |t|
+      t.string   :first_name
+      t.string   :last_name
+      t.datetime :created_on
+      t.datetime :updated_on
+    end
+  end
+
+  def _book_schema
+    proc do |t|
+      t.string   :name
+      t.text     :description
+      t.integer  :author_id
+      t.datetime :created_on
+      t.datetime :updated_on
+    end
+  end
+
+  def _author_model_create
+    Object.const_set :Author, Class.new(BaseClass) do
+      def self.connection; BaseClass.connection; end
+    end
+  end
+
+  def _book_model_create
+    Object.const_set :Book, Class.new(BaseClass) do
+      def self.connection; BaseClass.connection; end
+    end
+  end
+
+  def remove_ar_model_classes
+    Object.send :remove_const, :BaseClass
+
+    Object.send :remove_const, :Author
+    Object.send :remove_const, :Book
+  end
+end
+
+RSpec.configure do |rspec|
+  rspec.include_context 'with active_record',
+                        :with_active_record => true
+end


### PR DESCRIPTION
Fleshes out middleware specs that were lacking, and adds a few refactorings/features as well.

- Adds `ManageIQPerformance.profile_env_for`
    * Simply a wrapper for handling the autoname generation for `ManageIQ.profile` via the current backtrace.
    * Much easier to test in isolation, though existing tests were left in as well
- Adds `ActiveRecordQueries.clear_memoized_logger_vars`
    * Clears instance variables on the `ActiveSupport::Notification` subscribers we add that don't change with new instances of `ManageIQPerformance::Middleware` (i.e. when using `.profile`
- Adds ignoring of queries where the `payload[:cached]` is `true`
    * Different from the `IGNORED_PAYLOAD` value of `CACHE` (it seems), which is `postgresql` specific?
    * Optional change at this point, and wouldn't mind some feedback on this one