### PR TITLE
Add StacktraceCleaners::Full

### DIFF
--- a/lib/manageiq_performance/stacktrace_cleaners/full.rb
+++ b/lib/manageiq_performance/stacktrace_cleaners/full.rb
@@ -1,0 +1,9 @@
+module ManageIQPerformance
+  module StacktraceCleaners
+    class Full
+      def call stacktrace = Kernel.caller
+        stacktrace
+      end
+    end
+  end
+end

--- a/spec/manageiq_performance/stacktrace_cleaners/full_spec.rb
+++ b/spec/manageiq_performance/stacktrace_cleaners/full_spec.rb
@@ -1,0 +1,22 @@
+require "manageiq_performance/stacktrace_cleaners/full"
+
+describe ManageIQPerformance::StacktraceCleaners::Full do
+  describe "#call" do
+    it "returns the entire stacktrace" do
+      stacktrace = caller
+      expect(subject.call stacktrace).to eq stacktrace
+    end
+
+    it "defaults the stacktrace to caller" do
+      # It is required to do `Thread.current.backtrace[1..-1]` here because
+      # `caller` would not return the same result here as it would inside of
+      # the `Full#call` method.
+      #
+      # Also, Thread.current.backtrace by itself adds an entry to the callstack
+      # that is inside of the `Thread` module, so requesting everything after
+      # the first entry is also needed.
+      expected, result = [Thread.current.backtrace[1..-1], subject.call]
+      expect(result).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
For those who like drinking straight from the firehose...

Rational
--------
I originally wrote this (and didn't commit) because both the `Rails` and `Simple` stacktrace cleaners don't include provider gem code in the reduced stacktraces, so I just wanted something that gave me everything for a particular bug I was working on.

That said, I will probably also follow this up eventually with some configuration options for the `Rails` and `Simple`.  Possibly in the `Simple` case, just have it handle provider gems by default.