### PR TITLE
Fix failing specs

### DIFF
--- a/lib/manageiq_performance/reporter.rb
+++ b/lib/manageiq_performance/reporter.rb
@@ -32,7 +32,7 @@ module ManageIQPerformance
     # Collection
 
     def collect_data
-      Dir["#{@run_dir}/*"].each do |request_dir|
+      Dir["#{@run_dir}/*"].sort.each do |request_dir|
         request_id = File.basename request_dir
         @report_data[request_id]         ||= {}
         @report_data[request_id]["avgs"] ||= {}
@@ -43,7 +43,7 @@ module ManageIQPerformance
     end
 
     def gather_request_times request_dir, request_id
-      Dir["#{request_dir}/*.info"].inject(@report_data[request_id]) do |data, info_file|
+      Dir["#{request_dir}/*.info"].sort.inject(@report_data[request_id]) do |data, info_file|
         info = YAML.load_file(info_file) || {}
 
         data["ms"]           ||= []
@@ -58,7 +58,7 @@ module ManageIQPerformance
     end
 
     def gather_db_info request_dir, request_id
-      Dir["#{request_dir}/*.queries"].inject(@report_data[request_id]) do |data, info_file|
+      Dir["#{request_dir}/*.queries"].sort.inject(@report_data[request_id]) do |data, info_file|
         queries = YAML.load_file(info_file)
 
         data["queries"]      ||= []

--- a/spec/manageiq_performance/reporter_spec.rb
+++ b/spec/manageiq_performance/reporter_spec.rb
@@ -8,7 +8,7 @@ describe ManageIQPerformance::Reporter do
   subject       { described_class.new run_dir }
 
   describe "#collect_data" do
-    let(:spec_dir) { File.expand_path "..", File.dirname(__FILE__) }
+    let(:spec_dir)              { File.expand_path "..", File.dirname(__FILE__) }
     let(:collect_data_base_dir) { "#{spec_dir}/support/spec_data/report_data" }
 
     context "with one request_id" do


### PR DESCRIPTION
By using `.sort` after `Dir` calls

I have seen this issue before, but when you use `Dir`, the default sort order from `Dir` is not always guaranteed to be alpha-numeric.

Might be OS specific, or something to do with file timestamps, but this will ensure consistent sort order.