### PR TITLE
[browser_mode.rb] Add whitelist

### DIFF
--- a/lib/manageiq_performance/configuration.rb
+++ b/lib/manageiq_performance/configuration.rb
@@ -10,7 +10,9 @@ module ManageIQPerformance
                                       :requestfile_dir
 
     BROWSER_MODE_CONFIG  = Struct.new :enabled?,
-                                      :always_on?
+                                      :always_on?,
+                                      :whitelist?,
+                                      :whitelist
 
     DEFAULTS = {
       "default_dir"          => "tmp/manageiq_performance",
@@ -140,7 +142,9 @@ module ManageIQPerformance
       defaults = DEFAULTS["browser_mode"]
       BROWSER_MODE_CONFIG.new(
         (opts["enabled"]   || defaults["enabled"]),
-        (opts["always_on"] || defaults["always_on"])
+        (opts["always_on"] || defaults["always_on"]),
+        !!opts["whitelist"],
+        opts["whitelist"]
       )
     end
   end

--- a/spec/manageiq_performance/configuration_spec.rb
+++ b/spec/manageiq_performance/configuration_spec.rb
@@ -29,6 +29,7 @@ shared_examples "the default config" do |config_options={}|
     ["monitor_queue?"]               => false,
     ["browser_mode", "enabled?"]     => false,
     ["browser_mode", "always_on?"]   => false,
+    ["browser_mode", "whitelist"]    => nil,
   }
 
   # Convert a default value to what is expected from a hash config.  Basically
@@ -190,6 +191,10 @@ describe ManageIQPerformance::Configuration do
         browser_mode:
           enabled: true
           always_on: true
+          whitelist:
+            - /vm_infra/explorer
+            - /vm_infra/x_button
+            - /dashboard/show
       YAML
     }
     before(:each) do
@@ -286,6 +291,20 @@ describe ManageIQPerformance::Configuration do
     it "defines ManageIQPerformance.config.browser_mode.always_on?" do
       expect(ManageIQPerformance.config.browser_mode.always_on?).to eq true
       expect(ManageIQPerformance.config["browser_mode"]["always_on"]).to eq true
+    end
+
+    it "defines ManageIQPerformance.config.browser_mode.whitelist?" do
+      expect(ManageIQPerformance.config.browser_mode.whitelist?).to eq true
+    end
+
+    it "defines ManageIQPerformance.config.browser_mode.whitelist" do
+      expected = %w[
+        /vm_infra/explorer
+        /vm_infra/x_button
+        /dashboard/show
+      ]
+      expect(ManageIQPerformance.config.browser_mode.whitelist).to eq expected
+      expect(ManageIQPerformance.config["browser_mode"]["whitelist"]).to eq expected
     end
   end
 


### PR DESCRIPTION
Allows specifying in the configuration a specific set of URLs that metrics should be captured on.  All others are ignored.

The whitelist can be set in the config by doing the following:

```yaml
browser_mode:
  enabled: true
  always_on: true
  whitelist:
    - /vm_infra/x_button
    - /vm_infra/report_data
    - /report
```

And will take precedence over the `always_on:` config.