### PR TITLE
[railtie/middleware.rb] Fixes deprecation warning

### DIFF
--- a/lib/manageiq_performance/railtie/middleware.rb
+++ b/lib/manageiq_performance/railtie/middleware.rb
@@ -9,7 +9,7 @@ module ManageIQPerformance
 
       if ManageIQPerformance.config.browser_mode.enabled?
         require 'manageiq_performance/browser_mode_middleware'
-        app.middleware.insert_before "ManageIQPerformance::Middleware", "ManageIQPerformance::BrowserModeMiddleware"
+        app.middleware.insert_before ManageIQPerformance::Middleware, ManageIQPerformance::BrowserModeMiddleware
       end
     end
 


### PR DESCRIPTION
Support for using Strings/Symbols for registering middleware was deprecated in Rails here:

https://github.com/rails/rails/commit/83b767ce

Simply using constants works just fine.