### PR TITLE
Fixes to `miqperf benchmark`

### DIFF
--- a/lib/manageiq_performance/commands/benchmark.rb
+++ b/lib/manageiq_performance/commands/benchmark.rb
@@ -14,7 +14,7 @@ module ManageIQPerformance
       end
 
       def initialize(args)
-        @opts     = {:samples => 1, :api => false}
+        @opts     = {:samples => 1, :method => :get, :api => false}
         parse_env_variables
         option_parser.parse!(args)
         @path     = args.first
@@ -25,7 +25,7 @@ module ManageIQPerformance
           requestfile = @opts.delete(:requestfile)
           requests = Reporting::RequestfileBuilder.load requestfile
         elsif @path
-          requests = [{:method => :get, :path => @path}]
+          requests = [{:method => @opts[:method], :path => @path}]
         else # Invalid:  display help and exit
           puts option_parser.help
           exit
@@ -88,7 +88,7 @@ module ManageIQPerformance
       end
 
       def http_method
-        Proc.new { @opts[:ignore_ssl] = true }
+        Proc.new {|meth| @opts[:method] = meth }
       end
 
       def disable_ssl

--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'openssl'
 require 'logger'
 require 'uri'
 

--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -49,7 +49,7 @@ module ManageIQPerformance
     def nethttp_request(method, path, options={})
       payload       = (options[:params] || '') if method == :post
       request_args  = Array(payload)
-      request_args << (options[:headers] || full_request_headers)
+      request_args << build_headers options[:headers]
 
       unless %w[/ /api/auth /dashboard/authenticate].include?(path) # logged already
         log "--> making #{method.to_s.upcase} request: #{path}"
@@ -114,6 +114,12 @@ module ManageIQPerformance
         token_hdr            => @session,
         'MIQ_PERF_TIMESTAMP' => timestamp
       })
+    end
+
+    def build_headers custom_headers = nil
+      (custom_headers || full_request_headers).tap do |headers|
+        headers.delete_if { |k,v| v.nil? }
+      end
     end
 
     def credentials

--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -141,7 +141,7 @@ module ManageIQPerformance
     end
 
     def ignore_ssl_cert?
-      using_ssl? && ignore_cert?
+      using_ssl? && @ignore_cert
     end
   end
 end


### PR DESCRIPTION
- Fixes `nil` headers
- Fixes `--method` flag not being respected
- Fixes `OpenSSL` constant missing issue
- Fixes `ManageIQPerformance::Requestor#ignore_ssl_cert?`