### PR TITLE
`miqperf benchmark` enhancements

### DIFF
--- a/lib/manageiq_performance/commands/benchmark.rb
+++ b/lib/manageiq_performance/commands/benchmark.rb
@@ -26,7 +26,7 @@ module ManageIQPerformance
           requests = Reporting::RequestfileBuilder.load requestfile
         elsif @path
           request_opts = {}
-          [:data].each do |key|
+          [:data, :inspect_body].each do |key|
             request_opts[key] = @opts[key] if @opts.has_key?(key)
           end
 
@@ -78,6 +78,7 @@ module ManageIQPerformance
           opt.on("-HHOST", "--host=HOST",          "MIQ endpoint to target", define_host)
           opt.on("-mMETH", "--method=METHOD",      "HTTP method (def: GET)", http_method)
           opt.on(          "--data=DATA",          "Request data",           http_data)
+          opt.on(          "--inspect-body",       "Show last request body", inspect_body)
           opt.on("-d",     "--no-ssl",             "Disable SSL verify",     disable_ssl)
           opt.on("-r",     "--requestfile [FILE]", "Requestfile to use",     requestfile)
           opt.on("-cNUM",  "--count=NUM",          "Repeat request N times", set_count)
@@ -100,6 +101,10 @@ module ManageIQPerformance
 
       def http_data
         Proc.new {|data| @opts[:data] = data }
+      end
+
+      def inspect_body
+        Proc.new { @opts[:inspect_body] = true }
       end
 
       def disable_ssl

--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -40,8 +40,16 @@ module ManageIQPerformance
       nethttp_request(:get, path, options)
     end
 
+    def patch(path, options={})
+      nethttp_request(:patch, path, options)
+    end
+
     def post(path, options={})
       nethttp_request(:post, path, options)
+    end
+
+    def put(path, options={})
+      nethttp_request(:put, path, options)
     end
 
     private

--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -59,7 +59,9 @@ module ManageIQPerformance
       request_args  = Array(payload)
       request_args << build_headers options[:headers]
 
-      unless %w[/ /api/auth /dashboard/authenticate].include?(path) # logged already
+      login_route = %w[/ /api/auth /dashboard/authenticate].include?(path)
+
+      unless login_route  # logged already
         log "--> making #{method.to_s.upcase} request: #{path}"
       end
 
@@ -70,6 +72,8 @@ module ManageIQPerformance
           set_cookie_field = response.get_fields('set-cookie')
           @session         = set_cookie_field[0] if set_cookie_field
         end
+        log response.body.class if options[:inspect_body] && !login_route
+        log response.body       if options[:inspect_body] && !login_route
       end
     end
 

--- a/lib/manageiq_performance/requestor.rb
+++ b/lib/manageiq_performance/requestor.rb
@@ -55,7 +55,7 @@ module ManageIQPerformance
     private
 
     def nethttp_request(method, path, options={})
-      payload       = (options[:params] || '') if method == :post
+      payload       = build_request_payload_for method, options
       request_args  = Array(payload)
       request_args << build_headers options[:headers]
 
@@ -90,6 +90,12 @@ module ManageIQPerformance
         nethttp_request :post, "/dashboard/authenticate",
                         :params  => credentials, :headers => hdrs
       end
+    end
+
+    def build_request_payload_for method, request_options
+      return request_options[:params] || '' if method == :post && !request_options[:data]
+      return request_options[:data]         if method != :get && request_options[:data]
+      nil
     end
 
     def csrf_token


### PR DESCRIPTION
- Adds support for `PATCH` and `PUT` style requests
- Adds `--data` flag to allow passing in a body with a request
- Adds `--inspect-body` flag to log the response from the server (helps with debugging)

~~Built off of https://github.com/ManageIQ/manageiq-performance/pull/44, and have some other changes in here that at least need an update, or might just be removed, so won't be merging as is.~~ This is now ready to be merged after a review.