### PR TITLE
[README] Add some badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-ManageIQPerformance
-===================
+ManageIQ Performance
+====================
+
+[![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/manageiq/performance?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+[![Build Status](https://travis-ci.org/ManageIQ/manageiq-performance.svg)](https://travis-ci.org/ManageIQ/manageiq-performance)
+[![Code Climate](https://codeclimate.com/github/ManageIQ/manageiq-performance/badges/gpa.svg)](https://codeclimate.com/github/ManageIQ/manageiq-performance)
+[![Codacy](https://api.codacy.com/project/badge/grade/9ffce48ccb924020ae8f9e698048e9a4)](https://www.codacy.com/app/ManageIQ/manageiq-performance)
+
 Libraries and utilities for testing, profiling, benchmarking, and debugging
 performance bottlenecks on the ManageIQ application.  Includes, but not limited
 to:


### PR DESCRIPTION
This is a subset of https://github.com/ManageIQ/manageiq-performance/pull/4 which has gone pretty stale at this point.  That said, I want some of these badges to be included, and some tracking of what we should also work towards adding in addition to what I have included in this PR.

Updates the `README.md` to include badges that are currently setup for this gem.  Ones left out (to be added later, or are not valid):

- Gem Version (not released on `rubygems.org` yet, so still a git gem)
- Code Coverage (don't have code coverage setup in the test suite yet)
- Dependency Status (invalid without this being on `gitlab`)
- Hakiri/Security (don't think the account is setup for this repo yet)

I will also add a separate issue(s) to track the above.

Also, updates `gitter` to a room that is currently valid.  I don't think we need a special room for this repo, since the performance room doesn't get enough traffic as it is.