### PR TITLE
Add flamegraph support to analyze

### DIFF
--- a/lib/manageiq_performance/configuration.rb
+++ b/lib/manageiq_performance/configuration.rb
@@ -112,6 +112,10 @@ module ManageIQPerformance
         end
     end
 
+    def custom_flamegraph_bin
+      self["custom_flamegraph_bin"]
+    end
+
     private
 
     def self.load_config_file

--- a/spec/manageiq_performance/configuration_spec.rb
+++ b/spec/manageiq_performance/configuration_spec.rb
@@ -18,6 +18,7 @@ shared_examples "the default config" do |config_options={}|
     ["include_sql_queries?"]         => true,
     ["include_memsize?"]             => false,
     ["stacktrace_cleaner"]           => ManageIQPerformance::StacktraceCleaners::Simple,
+    ["custom_flamegraph_bin"]        => nil,
     ["requestor", "username"]        => "admin",
     ["requestor", "password"]        => "smartvm",
     ["requestor", "host"]            => "http://localhost:3000",
@@ -173,6 +174,7 @@ describe ManageIQPerformance::Configuration do
         include_sql_queries: false
         include_memsize: true
         stacktrace_cleaner: rails
+        custom_flamegraph_bin: /path/to/flamegraph/flamegraph.pl
         requestor:
           username: foobar
           password: p@ssw0rd
@@ -234,6 +236,11 @@ describe ManageIQPerformance::Configuration do
     it "defines ManageIQPerformance.config.stacktrace_cleaner" do
       expect(ManageIQPerformance.config.stacktrace_cleaner).to eq ManageIQPerformance::StacktraceCleaners::Rails
       expect(ManageIQPerformance.config["stacktrace_cleaner"]).to eq "rails"
+    end
+
+    it "defines ManageIQPerformance.config.custom_flamegraph_bin" do
+      expect(ManageIQPerformance.config.custom_flamegraph_bin).to eq "/path/to/flamegraph/flamegraph.pl"
+      expect(ManageIQPerformance.config["custom_flamegraph_bin"]).to eq "/path/to/flamegraph/flamegraph.pl"
     end
 
     it "defines ManageIQPerformance.config.requestor.username" do


### PR DESCRIPTION
Hooks in support in `miqperf analyze` to allow for generating flamegraphs instead of using the cli to browse through the stack traces.

Two CLI flags were added:

- `--flamegraph`:  Will generate a flamegraph in the directory instead of using the stackprof CLI
- `--open`:  When used with `--flamegraph` (on OSX), will open up the generated `.svg` in the browser

Also add a top level config value to configure a custom `flamegraph.pl` script:

```yaml
custom_flamegraph_bin: /path/to/custom/flamegraph.pl
```

In case it is desired to use that instead of the one that ships with `StackProf`, as that one is a relatively old version.


Links
-----

- FlameGraph repo:  https://github.com/brendangregg/FlameGraph