### PR TITLE
[template_helper.rb] Support Ruby 2.6

### DIFF
--- a/tasks/appliance_installation_script_generator.rake
+++ b/tasks/appliance_installation_script_generator.rake
@@ -23,7 +23,7 @@ task :generate_install_script do
   @output_filename   = SCRIPT_FILENAME
 
   b = binding
-  File.write @output_filename, ERB.new(@template, nil, "-").result(b)
+  File.write @output_filename, process_erb(@template, b)
   puts "Generated #{@output_filename}"
 end
 

--- a/tasks/support/template_helper.rb
+++ b/tasks/support/template_helper.rb
@@ -4,8 +4,7 @@ module TemplateHelper
     set_locals locals, partial_binding
 
     template = get_template_for partial
-
-    ERB.new(template, nil, "-").result(partial_binding)
+    process_erb(template, partial_binding)
   end
 
   def set_locals locals, local_binding
@@ -21,5 +20,15 @@ module TemplateHelper
 
   def template_dir
     @template_dir ||= File.expand_path "../templates", __FILE__
+  end
+
+  if RUBY_VERSION >= "2.6"
+    def process_erb template, erb_binding
+      ERB.new(template, trim_mode: "-").result(erb_binding)
+    end
+  else
+    def process_erb template, erb_binding
+      ERB.new(template, nil, "-").result(erb_binding)
+    end
   end
 end


### PR DESCRIPTION
Erb.new switched to keyword args in Ruby 2.6+, which causes a Ruby 3 deprecation warning.

This helper method, `process_erb`, allows the code to work in pre-Ruby 2.6 without breaking, and post 2.6 without the deprecation warnings.