### PR TITLE
[gem_base64_spec.rb] Fix for Gem::Package#build

### DIFF
--- a/spec/tasks/support/gem_base64_spec.rb
+++ b/spec/tasks/support/gem_base64_spec.rb
@@ -10,9 +10,17 @@ def build_gem file
   FileUtils.touch file
   file_obj = File.new(file, "w+")
 
-  Gem::Package.new(file_obj)
-              .tap{ |p| p.spec = GemBase64.miqperf_gemspec }
-              .build
+  Gem.load_yaml
+
+  gem_pkg = Gem::Package.new(file_obj).tap { |p| p.spec = GemBase64.miqperf_gemspec }
+  gem_pkg.setup_signer
+  gem_pkg.instance_variable_get(:@gem).with_write_io do |gem_io|
+    Gem::Package::TarWriter.new gem_io do |gem|
+      gem_pkg.add_metadata  gem
+      gem_pkg.add_contents  gem
+      gem_pkg.add_checksums gem
+    end
+  end
 end
 
 def decode_and_untar gem_string, pattern="*"


### PR DESCRIPTION
In newer versions of rubygems, a small section of `Gem::Package#build` relies on the `@gem`'s `@path` variable to be present and work with `File.basename`.  Since this is not there, it fails and in previous versions of it would only need to work with the `@spec` to get this value.

Since we are doing a bit of fudging to get tihs to work, this change just implements the parts of `Gem::Package#build` that we for our purposes instead of trying more hacks to that method to do what we need it to.