### PR TITLE
Add additional functionality to miqperf report

### DIFF
--- a/lib/manageiq_performance/commands/report.rb
+++ b/lib/manageiq_performance/commands/report.rb
@@ -35,8 +35,10 @@ module ManageIQPerformance
           opt.separator ""
           opt.separator "Options"
 
-          opt.on("-f", "--first", "Report on first suite", first_dir)
-          opt.on("-l", "--last",  "Report on last suite",  last_dir)
+          opt.on("-f", "--first",   "Report on first suite",          first_dir)
+          opt.on("-l", "--last",    "Report on last suite",           last_dir)
+          opt.on("-n", "--num=NUM", "Report on N suite",     Integer, n_dir)
+
           opt.on("-h", "--help",  "Show this message") { puts opt; exit }
         end
       end
@@ -47,6 +49,17 @@ module ManageIQPerformance
 
       def first_dir
         Proc.new { @opts[:run_dir] = sorted_dirs.first }
+      end
+
+      def n_dir
+        Proc.new do |n|
+          # For the user, don't have this 0 indexed
+          raise "Err: 0 is invalid! -n/--num is 1 indexed." if n == 0
+
+          n = n - 1 if n > 0
+
+          @opts[:run_dir] = sorted_dirs[n.to_i]
+        end
       end
 
       def last_dir


### PR DESCRIPTION
- Adds `-n`/`--num` options
- Adds `--info`, `--memory`, and `--queries` action switches


### `-n`/`--num`

Allows for specifying a custom relative suite directory via the `-n`/`--num` switch.

Accepts both positive and negative numbers, which means that `--first` and `--last` are equivalent to `--num=1` and `--num=-1` respectively.

Example:

```console
# Fetch the third to last run dir in tmp/manageiq_performance
$ miqperf report -n -3
# Fetch the fifth run dir in tmp/manageiq_performance
$ miqperf report -n 5
```

### `--info`, `--memory`, `--queries`

Instead of printing a summary of the queries/info data, actually open the all respective files for a given type in the users `$EDITOR` (defaults to `vi` if `$EDITOR` isn't set)

Example:

```
$ miqperf report --last --queries
```