### PR TITLE
[commands/benchmark.rb] Allow file path for JSON post

### DIFF
--- a/lib/manageiq_performance/commands/benchmark.rb
+++ b/lib/manageiq_performance/commands/benchmark.rb
@@ -100,7 +100,10 @@ module ManageIQPerformance
       end
 
       def http_data
-        Proc.new {|data| @opts[:data] = data }
+        Proc.new do |data|
+          @opts[:data] = data
+          @opts[:data] = File.read(data) if File.exist?(data)
+        end
       end
 
       def inspect_body


### PR DESCRIPTION
Allow passing a file path, instead JSON blob string, for `--http-data` when using the `miqperf benchmark ...` command.

Allows for simple editing in and editor of choice and easier manipulation of complex JSON data POST actions.